### PR TITLE
Implement YANG choice statement support

### DIFF
--- a/src/nodes/node.rs
+++ b/src/nodes/node.rs
@@ -301,6 +301,7 @@ pub struct ChoiceNode {
     pub mandatory: Option<MandatoryNode>,
     pub when: Option<WhenNode>,
     pub config: Option<ConfigNode>,
+    pub cases: Vec<CaseNode>,
 }
 
 #[derive(Debug, PartialEq, Clone, Default)]
@@ -470,6 +471,10 @@ impl ActionNode {
 pub struct CaseNode {
     pub name: String,
     pub description: Option<String>,
+    pub reference: Option<String>,
+    pub status: Option<StatusNode>,
+    pub when: Option<WhenNode>,
+    pub d: DatadefNode,
 }
 
 impl CaseNode {


### PR DESCRIPTION
## Summary
- Add comprehensive support for YANG choice statements in the Entry system
- Implement proper parsing and storage of choice cases with data definitions
- Support both explicit case statements and implicit short case syntax

## Changes
- **Enhanced Node Structures**: Added `cases` field to `ChoiceNode` and expanded `CaseNode` with data definitions
- **Entry System Updates**: Added `ChoiceEntry` kind and `choice_cases` field to store case branches
- **Processing Functions**: Implemented `choice_entry()` function and updated all relevant entry processors
- **AST Parsing**: Enhanced choice and case parsing to capture full statement structures

## Test Results
- Successfully parses choice statements with multiple cases
- Correctly handles implicit case syntax (ShortCaseStmt)
- Maintains proper parent-child relationships between choices and cases
- Tested with sample YANG files containing nested choice structures

## Compatibility
- Maintains backward compatibility with existing Entry API
- No breaking changes to public interfaces
- Follows existing codebase patterns and conventions

🤖 Generated with [Claude Code](https://claude.ai/code)