### PR TITLE
Flatten YANG choice cases and capture leafref path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 use std::process;
 
-use parol::{build::Builder, InnerAttributes, ParolErrorReporter};
+use parol::{InnerAttributes, ParolErrorReporter, build::Builder};
 use parol_runtime::Report;
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ extern crate parol_runtime;
 use crate::yang_grammar::YangGrammar;
 use crate::yang_parser::parse;
 use anyhow::{Context, Result};
-use parol_runtime::{log::debug, Report};
+use parol_runtime::{Report, log::debug};
 use std::{env, fs, time::Instant};
 
 struct ErrorReporter;

--- a/src/nodes/ast.rs
+++ b/src/nodes/ast.rs
@@ -848,7 +848,11 @@ fn type_stmt(m: &TypeStmt) -> TypeNode {
                     let base = base_stmt(&m.base_stmt);
                     node.base = Some(base);
                 }
-                TypeStmtListGroup::LeafrefSpecification(_m) => {}
+                TypeStmtListGroup::LeafrefSpecification(m) => {
+                    if let LeafrefSpecification::PathStmt(p) = &*m.leafref_specification {
+                        node.path = Some(ystring(&p.path_stmt.ystring));
+                    }
+                }
                 TypeStmtListGroup::StringRestrictions(_m) => {}
                 TypeStmtListGroup::RangeStmt(m) => {
                     let n = range(&m.range_stmt, kind);

--- a/src/nodes/ast.rs
+++ b/src/nodes/ast.rs
@@ -988,7 +988,7 @@ fn choice(m: &ChoiceStmt) -> ChoiceNode {
 fn case(m: &CaseStmt) -> CaseNode {
     let name = identifier_arg_str(&m.identifier_arg_str);
     let mut node = CaseNode::new(name);
-    
+
     if let CaseStmtSuffix::LBraceCaseStmtListRBrace(m) = &*m.case_stmt_suffix {
         for m in m.case_stmt_list.iter() {
             match &*m.case_stmt_list_group {
@@ -1009,7 +1009,7 @@ fn case(m: &CaseStmt) -> CaseNode {
             }
         }
     }
-    
+
     node
 }
 
@@ -1162,7 +1162,7 @@ fn date_arg_str(m: &DateArgStrSuffix) -> String {
 fn action(m: &ActionStmt) -> ActionNode {
     let name = identifier_arg_str(&m.identifier_arg_str);
     let mut node = ActionNode::new(name);
-    
+
     if let ActionStmtSuffix::LBraceActionStmtListRBrace(m) = &*m.action_stmt_suffix {
         for m in m.action_stmt_list.iter() {
             match &*m.action_stmt_list_group {
@@ -1188,7 +1188,7 @@ fn action(m: &ActionStmt) -> ActionNode {
             }
         }
     }
-    
+
     node
 }
 

--- a/src/nodes/node.rs
+++ b/src/nodes/node.rs
@@ -528,6 +528,10 @@ pub struct TypeNode {
     pub base: Option<String>,
     pub union: Vec<TypeNode>,
     pub typedef: Option<String>,
+    // Populated for YangType::Leafref: the `path "..."` argument from
+    // the `leafref` type specification. Survives typedef resolution
+    // (typedefs wrapping a leafref carry the underlying path).
+    pub path: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Default, Eq, Hash)]

--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -40,6 +40,16 @@ pub struct Entry {
     pub type_node: Option<TypeNode>,
     pub list_attr: Option<ListAttr>,
     pub choice_cases: Option<Vec<Rc<Entry>>>,
+
+    // When this entry was introduced by a `case` inside a `choice`,
+    // these record the choice and case names so consumers can reason
+    // about mutual exclusion at commit time. Per RFC 7950 §7.9.2,
+    // choice/case nodes do not themselves appear in the data tree;
+    // only the case's direct children do. We flatten accordingly —
+    // the case's children land in the choice's parent `dir`, tagged
+    // here with the choice and case names.
+    pub choice: RefCell<Option<String>>,
+    pub case: RefCell<Option<String>>,
 }
 
 impl Entry {
@@ -487,54 +497,48 @@ where
             return;
         }
     }
-    let mut e = Entry::new_choice(c.name.clone());
-    e.mandatory = c.mandatory.as_ref().map(|m| m.mandatory).unwrap_or(false);
 
-    // Collect all cases first
-    let mut cases = Vec::new();
+    // Per RFC 7950 §7.9.2, neither the `choice` node nor its `case`
+    // nodes appear in the data tree — only the case's direct data
+    // children do. We flatten each case's children into the choice's
+    // parent `ent.dir` and tag each added entry with (choice, case)
+    // metadata so consumers can enforce mutual exclusion later.
+    let choice_name = c.name.clone();
 
-    // Process each case in the choice
     for case in c.cases.iter() {
-        let mut case_entry = Entry::new_dir(case.name.clone());
-        case_entry
-            .extension
-            .insert("case".to_string(), "true".to_string());
-        let case_rc = Rc::new(case_entry);
+        let case_name = case.name.clone();
+        let len_before = ent.dir.borrow().len();
 
-        // Process data definitions within the case
         for uses in case.d.uses.iter() {
-            group_resolve(top, store, &uses.name, case_rc.clone());
+            group_resolve(top, store, &uses.name, ent.clone());
         }
-        for c in case.d.container.iter() {
-            container_entry(top, store, c, case_rc.clone());
+        for cnode in case.d.container.iter() {
+            container_entry(top, store, cnode, ent.clone());
         }
         for leaf in case.d.leaf.iter() {
-            leaf_entry(top, store, leaf, case_rc.clone());
+            leaf_entry(top, store, leaf, ent.clone());
         }
         for list in case.d.list.iter() {
-            list_entry(top, store, list, case_rc.clone());
+            list_entry(top, store, list, ent.clone());
         }
         for leaf_list in case.d.leaf_list.iter() {
-            leaf_list_entry(top, store, leaf_list, case_rc.clone());
+            leaf_list_entry(top, store, leaf_list, ent.clone());
         }
-        for choice in case.d.choice.iter() {
-            choice_entry(top, store, choice, case_rc.clone());
+        for nested in case.d.choice.iter() {
+            choice_entry(top, store, nested, ent.clone());
         }
 
-        cases.push(case_rc);
+        // Tag the newly added entries. Skip any already tagged by a
+        // nested `choice_entry` recursion — the innermost choice/case
+        // wins (outer-nesting metadata is not currently represented).
+        let dir = ent.dir.borrow();
+        for child in dir[len_before..].iter() {
+            if child.choice.borrow().is_none() {
+                *child.choice.borrow_mut() = Some(choice_name.clone());
+                *child.case.borrow_mut() = Some(case_name.clone());
+            }
+        }
     }
-
-    // Set the cases
-    e.choice_cases = Some(cases.clone());
-    let rc = Rc::new(e);
-
-    // Set parent references
-    for case_rc in cases {
-        case_rc.parent.replace(Some(rc.clone()));
-    }
-
-    ent.dir.borrow_mut().push(rc.clone());
-    rc.parent.replace(Some(ent.clone()));
 }
 
 pub fn container_entry<T>(top: &T, store: &YangStore, c: &ContainerNode, ent: Rc<Entry>)

--- a/tests/choice_flatten.rs
+++ b/tests/choice_flatten.rs
@@ -1,0 +1,56 @@
+// Integration test for YANG `choice` case flattening.
+//
+// Per RFC 7950 §7.9.2, `choice` and `case` nodes do not appear in
+// the data tree. libyang's `choice_entry` flattens each case's direct
+// children into the choice's parent `dir`, tagging them with
+// (choice, case) metadata on the Entry.
+//
+// This test builds a YangStore from a tiny module with a two-case
+// choice inside a container, converts it to an Entry tree, and
+// asserts the expected shape.
+
+use libyang::{Entry, YangStore, to_entry};
+use std::rc::Rc;
+
+fn load(name: &str, yang_dir: &str) -> Rc<Entry> {
+    let mut store = YangStore::new();
+    store.add_path(yang_dir);
+    store.read_with_resolve(name).expect("parse / resolve");
+    store.identity_resolve();
+    let module = store.find_module(name).expect("module found");
+    to_entry(&store, module)
+}
+
+fn find_child<'a>(ent: &'a Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
+    ent.dir.borrow().iter().find(|e| e.name == name).cloned()
+}
+
+#[test]
+fn choice_cases_flatten_into_parent_dir() {
+    // tests/yang/choice-sample.yang has:
+    //   container options {
+    //     choice option {
+    //       case ao { leaf ao-keychain { type string; } }
+    //       case md5 { leaf md5-keychain { type string; } }
+    //     }
+    //   }
+    let root = load("choice-sample", "tests/yang");
+    let options = find_child(&root, "options").expect("options");
+
+    // After flattening, the case-child leaves should appear directly
+    // under `options`, NOT under a nested `option` ChoiceEntry node.
+    let ao_keychain = find_child(&options, "ao-keychain").expect("ao-keychain reachable");
+    let md5_keychain = find_child(&options, "md5-keychain").expect("md5-keychain reachable");
+
+    // And they should carry choice/case metadata.
+    assert_eq!(ao_keychain.choice.borrow().as_deref(), Some("option"));
+    assert_eq!(ao_keychain.case.borrow().as_deref(), Some("ao"));
+    assert_eq!(md5_keychain.choice.borrow().as_deref(), Some("option"));
+    assert_eq!(md5_keychain.case.borrow().as_deref(), Some("md5"));
+
+    // The ChoiceEntry itself must NOT appear as a named path segment.
+    assert!(
+        find_child(&options, "option").is_none(),
+        "choice node 'option' should not appear in parent dir"
+    );
+}

--- a/tests/leafref_path.rs
+++ b/tests/leafref_path.rs
@@ -1,0 +1,41 @@
+// Integration test: leafref type captures its `path "..."` argument
+// on TypeNode, and the path survives typedef resolution (a typedef
+// whose underlying type is a leafref propagates the path to the
+// Entry of a leaf that uses the typedef).
+
+use libyang::{to_entry, Entry, YangStore};
+use std::rc::Rc;
+
+fn load(name: &str, yang_dir: &str) -> Rc<Entry> {
+    let mut store = YangStore::new();
+    store.add_path(yang_dir);
+    store.read_with_resolve(name).expect("parse / resolve");
+    store.identity_resolve();
+    let module = store.find_module(name).expect("module found");
+    to_entry(&store, module)
+}
+
+fn find_child<'a>(ent: &'a Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
+    ent.dir.borrow().iter().find(|e| e.name == name).cloned()
+}
+
+#[test]
+fn leafref_direct_captures_path() {
+    // tests/yang/leafref-sample.yang has a direct `type leafref { path
+    // "/items/item/name"; }` leaf.
+    let root = load("leafref-sample", "tests/yang");
+    let picked = find_child(&root, "picked").expect("picked leaf");
+    let t = picked.type_node.as_ref().expect("type_node");
+    assert_eq!(t.path.as_deref(), Some("/items/item/name"));
+}
+
+#[test]
+fn leafref_through_typedef_captures_path() {
+    // tests/yang/leafref-sample.yang also has `typedef item-ref {
+    // type leafref { path "/items/item/name"; } }` and a leaf using
+    // `type item-ref`. The path must survive typedef resolution.
+    let root = load("leafref-sample", "tests/yang");
+    let picked_td = find_child(&root, "picked-via-typedef").expect("picked-via-typedef leaf");
+    let t = picked_td.type_node.as_ref().expect("type_node");
+    assert_eq!(t.path.as_deref(), Some("/items/item/name"));
+}

--- a/tests/leafref_path.rs
+++ b/tests/leafref_path.rs
@@ -3,7 +3,7 @@
 // whose underlying type is a leafref propagates the path to the
 // Entry of a leaf that uses the typedef).
 
-use libyang::{to_entry, Entry, YangStore};
+use libyang::{Entry, YangStore, to_entry};
 use std::rc::Rc;
 
 fn load(name: &str, yang_dir: &str) -> Rc<Entry> {

--- a/tests/yang/choice-sample.yang
+++ b/tests/yang/choice-sample.yang
@@ -1,0 +1,20 @@
+module choice-sample {
+  yang-version "1";
+  namespace "urn:test:choice-sample";
+  prefix "cs";
+
+  container options {
+    choice option {
+      case ao {
+        leaf ao-keychain {
+          type string;
+        }
+      }
+      case md5 {
+        leaf md5-keychain {
+          type string;
+        }
+      }
+    }
+  }
+}

--- a/tests/yang/leafref-sample.yang
+++ b/tests/yang/leafref-sample.yang
@@ -1,0 +1,31 @@
+module leafref-sample {
+  yang-version "1";
+  namespace "urn:test:leafref-sample";
+  prefix "lr";
+
+  typedef item-ref {
+    type leafref {
+      path "/items/item/name";
+    }
+    description "Typedef wrapping a leafref.";
+  }
+
+  container items {
+    list item {
+      key "name";
+      leaf name {
+        type string;
+      }
+    }
+  }
+
+  leaf picked {
+    type leafref {
+      path "/items/item/name";
+    }
+  }
+
+  leaf picked-via-typedef {
+    type item-ref;
+  }
+}


### PR DESCRIPTION
## Summary

- **Flatten choice cases** into the parent `dir` per RFC 7950 §7.9.2 (choice/case nodes don't appear in the data tree). Each case's direct children now land in the choice's parent `Entry.dir` tagged with `(choice, case)` metadata via new `RefCell<Option<String>>` fields on `Entry`. Stops consumers (like zebra-rs's CLI parser) from having to walk `choice_cases` or special-case `ChoiceEntry`.
- **Capture leafref path** on `TypeNode` — previously the `path "..."` argument inside a `leafref` type spec was parsed but dropped (`_m => {}`). Now stored as `TypeNode.path: Option<String>` and survives typedef resolution (e.g. RFC 8177's `key-chain:key-chain-ref` wraps a leafref; the path reaches consumers).
- `EntryKind::ChoiceEntry` and `Entry.choice_cases` remain defined for future introspection but are no longer used as path segments.

## Test plan

- [x] `cargo build` — clean.
- [x] `cargo test --test choice_flatten` — 1/1 passes (cases surface under parent, `choice`/`case` metadata set, no `option` segment).
- [x] `cargo test --test leafref_path` — 2/2 passes (direct leafref + via-typedef).
- [x] Incidental `cargo fmt` cleanups included.

Generated with [Claude Code](https://claude.com/claude-code)