### PR TITLE
type-stmt: populate pattern and length from string-restrictions

### DIFF
--- a/src/nodes/ast.rs
+++ b/src/nodes/ast.rs
@@ -851,6 +851,15 @@ fn range(m: &RangeStmt, kind: YangType) -> RangeNode {
     }
 }
 
+fn length(m: &LengthStmt) -> RangeNode {
+    match &*m.range_arg_str {
+        RangeArgStr::RangeArg(m) => range_arg(&m.range_arg, YangType::Uint64),
+        RangeArgStr::DoubleQuotationRangeArgDoubleQuotation(m) => {
+            range_arg(&m.range_arg, YangType::Uint64)
+        }
+    }
+}
+
 fn enum_stmt(m: &EnumStmt) -> EnumNode {
     let name = match &*m.enum_arg_str.enum_arg_str_suffix {
         EnumArgStrSuffix::AsciiNoBrace(m) => m.ascii_no_brace.ascii_no_brace.text().to_string(),
@@ -887,7 +896,14 @@ fn type_stmt(m: &TypeStmt) -> TypeNode {
                         node.path = Some(ystring(&p.path_stmt.ystring));
                     }
                 }
-                TypeStmtListGroup::StringRestrictions(_m) => {}
+                TypeStmtListGroup::StringRestrictions(m) => match &*m.string_restrictions {
+                    StringRestrictions::PatternStmt(p) => {
+                        node.pattern = Some(ystring(&p.pattern_stmt.ystring));
+                    }
+                    StringRestrictions::LengthStmt(l) => {
+                        node.length = Some(length(&l.length_stmt));
+                    }
+                },
                 TypeStmtListGroup::RangeStmt(m) => {
                     let n = range(&m.range_stmt, kind);
                     node.range = Some(n);

--- a/src/nodes/node.rs
+++ b/src/nodes/node.rs
@@ -525,6 +525,7 @@ pub struct TypeNode {
     pub kind: YangType,
     pub description: Option<String>,
     pub pattern: Option<String>,
+    pub length: Option<RangeNode>,
     pub range: Option<RangeNode>,
     pub enum_stmt: Vec<EnumNode>,
     pub base: Option<String>,


### PR DESCRIPTION
## Summary

- `type_stmt` in `src/nodes/ast.rs` discarded the `StringRestrictions` arm, so `pattern` and `length` substatements under `type string` never reached `TypeNode`. Wire both up.
- Add `length: Option<RangeNode>` field on `TypeNode` (parsed as `RangeNode::U64`, matching YANG's `uint64`-typed length).
- New `length()` helper shares the existing `range_arg` numeric conversion via `RangeArgStr`.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --all` applied
- [ ] Downstream verification in zebra-rs: `type string { pattern '...'; }` leaves now reach `match_regexp` via `node.pattern.as_ref()` (currently silently fell through to the no-pattern path).

Generated with [Claude Code](https://claude.com/claude-code)