### PR TITLE
ystring: extract content of single-quoted YANG strings

### DIFF
--- a/src/nodes/ast.rs
+++ b/src/nodes/ast.rs
@@ -725,7 +725,31 @@ fn ystring(s: &Ystring) -> String {
                 }
             }
         }
-        BasicString::SQString(_m) => {}
+        BasicString::SQString(m) => {
+            for s in m.s_q_string.s_q_string_list.iter() {
+                match &*s.s_q_char {
+                    SQChar::SQUnescaped(m) => match &*m.s_q_unescaped {
+                        SQUnescaped::SQNoEscape(m) => {
+                            if first {
+                                first = false
+                            } else {
+                                line.push('\n');
+                            }
+                            line.push_str(m.s_q_no_escape.s_q_no_escape.text());
+                        }
+                        SQUnescaped::NonAscii(m) => {
+                            if first {
+                                first = false
+                            } else {
+                                line.push('\n');
+                            }
+                            line.push_str(m.non_ascii.non_ascii.text());
+                        }
+                    },
+                    SQChar::SQEscaped(_m) => {}
+                }
+            }
+        }
     }
     // Handle the YANG `+` continuation (RFC 7950 §6.1.3 — adjacent
     // quoted strings are concatenated with no inserted characters).


### PR DESCRIPTION
## Summary

- The `SQString` arm of `ystring()` was a no-op stub, so every single-quoted YANG value collapsed to an empty `String`.
- This silently bit `pattern '...'`, which is universally single-quoted (single quotes avoid backslash collisions with regex syntax). After PR #19 wired pattern parsing through, downstream consumers were seeing `TypeNode.pattern = Some("")`.
- Mirror the `DQString` arm: walk `s_q_string_list`, append each `SQNoEscape` / `NonAscii` token, share the same newline-between-chunks behavior and skip `SQEscaped` the same way `DQEscaped` is skipped.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --all` applied
- [ ] Downstream verification in zebra-rs: `TypeNode.pattern` now carries the actual regex string instead of an empty string.

Generated with [Claude Code](https://claude.com/claude-code)