### PR TITLE
type_resolve: resolve union arms for local typedefs and keep inline arms

### DIFF
--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -382,6 +382,14 @@ where
                     }
                 }
             }
+        } else {
+            // Inline union arm with a recognized kind (e.g.
+            // `type string { pattern '...'; }` written directly
+            // inside the union, not via a typedef reference). Keep
+            // it so the matcher can dispatch on it; the previous
+            // drop-on-the-floor behavior was the reason inline
+            // pattern-restricted string arms in unions never engaged.
+            nodes.push(node.clone());
         }
     }
     let mut type_node = type_node.clone();
@@ -415,7 +423,18 @@ where
         for typedef in top.get_typedef().iter() {
             if typedef.name == type_node.name {
                 if let Some(node) = &typedef.type_node {
-                    return Some(node.clone());
+                    let mut node = node.clone();
+                    node.typedef = Some(type_node.name.clone());
+                    if node.kind == YangType::Union {
+                        // A local typedef whose underlying type is a
+                        // union: resolve its Path arms the same way
+                        // the prefixed branch does, otherwise a leaf
+                        // like `type peer-id-or-all` reaches the
+                        // matcher with every arm still `kind = Path`
+                        // and nothing dispatches.
+                        return type_union_resolve(top, store, &node);
+                    }
+                    return Some(node);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Two cooperating gaps made local-typedef unions (e.g. `type peer-id-or-all` where the typedef's underlying type is `type union { type inet:ipv4-address; type inet:ipv6-address; type string { pattern "all"; } }`) reach downstream consumers with arms a matcher couldn't dispatch:

1. **`type_path_resolve`'s local-typedef branch** returned the typedef's `type_node` verbatim. The prefixed branch already called `type_union_resolve` to resolve inner `Path` arms (so `inet:ipv4-address` became a `String` arm tagged with `typedef = "inet:ipv4-address"`). The local branch did not — so inner arms stayed `kind = Path`.

2. **`type_union_resolve`** only pushed `Path`-kind arms after resolution. Inline arms with a recognized kind — e.g. `type string { pattern "all"; }` written directly inside the union — were silently dropped.

The combination meant zebra-rs's `clear bgp ipv4 neighbor <addr>` started failing with `% No such command` once string-pattern restrictions were actually applied (libyang #19 / #20), because the IPv4/IPv6 arms were unresolvable `Path` and the `"all"` arm had been dropped.

## Fix

- `type_path_resolve` local-typedef branch: mirror the prefixed branch — if the resolved typedef is a Union, run it through `type_union_resolve`.
- `type_union_resolve`: append non-`Path` inline arms as-is.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 2/2 pass
- [x] Downstream zebra-rs builds clean against the local path
- [ ] Live: `clear bgp ipv4 neighbor 10.0.0.5` parses; `clear bgp ipv4 neighbor all` parses; `clear bgp ipv4 neighbor garbage` is rejected.

Generated with [Claude Code](https://claude.com/claude-code)