### PR TITLE
type_resolve: keep inline arms in direct unions

### DIFF
--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -480,6 +480,15 @@ where
                 if let Some(node) = type_path_resolve(top, store, node) {
                     union_node.union.push(node);
                 }
+            } else {
+                // Inline arm with a recognized kind (e.g. `type uint32;`
+                // or `type string { pattern '...'; }` written directly
+                // inside the union, not via a typedef reference). Keep
+                // it so the matcher can dispatch on it; otherwise inline
+                // scalar / patterned-string arms silently disappear and
+                // a union like `union { uint32; inet:ipv4-address; }`
+                // only matches the ipv4-address arm.
+                union_node.union.push(node.clone());
             }
         }
         ent.type_node = Some(union_node);

--- a/tests/union_inline_arms.rs
+++ b/tests/union_inline_arms.rs
@@ -1,0 +1,59 @@
+// Integration test: inline union arms with a recognized built-in
+// kind (e.g. `type uint32;` written directly inside the union, not
+// via a typedef reference) must survive YANG store resolution so
+// the matcher can dispatch on them.
+//
+// Regression: a leaf declared as
+//     type union { type uint32; type inet:ipv4-address; }
+// previously kept only the path arm (ipv4-address) because
+// type_resolve's Union branch only pushed arms whose kind was Path.
+
+use libyang::{Entry, YangStore, YangType, to_entry};
+use std::rc::Rc;
+
+fn load(name: &str, yang_dir: &str) -> Rc<Entry> {
+    let mut store = YangStore::new();
+    store.add_path(yang_dir);
+    store.read_with_resolve(name).expect("parse / resolve");
+    store.identity_resolve();
+    let module = store.find_module(name).expect("module found");
+    to_entry(&store, module)
+}
+
+fn find_child<'a>(ent: &'a Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
+    ent.dir.borrow().iter().find(|e| e.name == name).cloned()
+}
+
+#[test]
+fn inline_union_keeps_builtin_and_typedef_arms() {
+    let root = load("union-sample", "tests/yang");
+    let leaf = find_child(&root, "area-id").expect("area-id leaf");
+    let t = leaf.type_node.as_ref().expect("type_node");
+    assert_eq!(t.kind, YangType::Union);
+    let kinds: Vec<YangType> = t.union.iter().map(|n| n.kind).collect();
+    assert!(
+        kinds.contains(&YangType::Uint32),
+        "uint32 arm must survive; got {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&YangType::String),
+        "ipv4-addr (resolves to string) arm must survive; got {kinds:?}"
+    );
+}
+
+#[test]
+fn inline_union_keeps_all_builtin_arms() {
+    let root = load("union-sample", "tests/yang");
+    let leaf = find_child(&root, "scalar-or-string").expect("scalar-or-string leaf");
+    let t = leaf.type_node.as_ref().expect("type_node");
+    assert_eq!(t.kind, YangType::Union);
+    let kinds: Vec<YangType> = t.union.iter().map(|n| n.kind).collect();
+    assert!(
+        kinds.contains(&YangType::Uint32),
+        "uint32 arm must survive; got {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&YangType::String),
+        "string arm must survive; got {kinds:?}"
+    );
+}

--- a/tests/yang/union-sample.yang
+++ b/tests/yang/union-sample.yang
@@ -1,0 +1,32 @@
+module union-sample {
+  yang-version 1.1;
+  namespace "urn:union-sample";
+  prefix us;
+
+  // Reduced repro of the area-id case: an inline union with a
+  // built-in scalar arm and a typedef-referenced arm. The matcher
+  // must see both arms; previously the scalar arm was dropped on
+  // the floor.
+
+  typedef ipv4-addr {
+    type string {
+      pattern '([0-9]+\.){3}[0-9]+';
+    }
+  }
+
+  leaf area-id {
+    type union {
+      type uint32;
+      type ipv4-addr;
+    }
+  }
+
+  // Same shape, all-inline (no typedef arm). Both arms are inline
+  // built-ins; both must survive.
+  leaf scalar-or-string {
+    type union {
+      type uint32;
+      type string;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fix `type_resolve`'s `Union` branch in `src/store/entry.rs` to preserve inline arms whose kind is not `Path` (e.g. `type uint32;` or `type string { pattern '...'; }` written directly inside a `union`). Previously only `Path` arms survived, so an inline union like `union { uint32; inet:ipv4-address; }` matched only the ipv4-address arm.
- Mirrors the same fix already present in the sister helper `type_union_resolve` (commit df536a8), which handles unions reached through a typedef. Inline-on-leaf unions now behave consistently with typedef'd ones.
- Repro case in zebra-rs: `router ospf area <decimal>` would not match when `area-id` was declared as `type union { type uint32; type inet:ipv4-address; }`, even though `router ospf area 0.0.0.0` (the path arm) did match.

## Test plan
- [x] `cargo test` — 6/6 pass (4 pre-existing + 2 new).
- [x] `cargo fmt --check` clean.
- [x] New `tests/union_inline_arms.rs` reproduces the `area-id` shape (`union { uint32; ipv4-addr; }`) and an all-inline-builtin variant (`union { uint32; string; }`), asserting both arms survive resolution.
- [ ] End-to-end: bump the `libyang` `rev` pin in `zebra-rs/Cargo.toml` after merge and confirm `router ospf area 0` matches in the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)