### PR TITLE
grammar: accept unquoted-identifier form of RFC 7950 string args

### DIFF
--- a/src/nodes/ast.rs
+++ b/src/nodes/ast.rs
@@ -696,7 +696,17 @@ fn yang_version(m: &YangVersionStmt) -> String {
 fn ystring(s: &Ystring) -> String {
     let mut line = String::new();
     let mut first = true;
-    match &*s.basic_string {
+    let (basic_string, ystring_opt) = match s {
+        Ystring::BasicStringYstringOpt(inner) => (&inner.basic_string, inner.ystring_opt.as_ref()),
+        // RFC 7950 §6.1.3 unquoted-string form. The `Identifier`
+        // token covers the common case (units / description /
+        // organization / etc. with a single bareword argument); the
+        // `+` concatenation grammar is reserved for the quoted form.
+        Ystring::Identifier(inner) => {
+            return inner.identifier.identifier.text().to_string();
+        }
+    };
+    match &**basic_string {
         BasicString::DQString(m) => {
             for s in m.d_q_string.d_q_string_list.iter() {
                 match &*s.d_q_char {
@@ -753,7 +763,7 @@ fn ystring(s: &Ystring) -> String {
     }
     // Handle the YANG `+` continuation (RFC 7950 §6.1.3 — adjacent
     // quoted strings are concatenated with no inserted characters).
-    if let Some(opt) = &s.ystring_opt {
+    if let Some(opt) = ystring_opt {
         line.push_str(&ystring(&opt.ystring));
     }
     line
@@ -1198,9 +1208,11 @@ fn extension(m: &ExtensionStmt) -> ExtensionNode {
 fn unknown(m: &UnknownStmt) -> UnknownNode {
     let name = identifier_ref(&m.identifier_ref);
     let mut node = UnknownNode::new(name);
-    if let UnknownStmtSuffix0::YstringUnknownStmtSuffix(m) = &*m.unknown_stmt_suffix0 {
-        node.argument = ystring(&m.ystring);
-    }
+    // `ystring` is shared between both UnknownStmtSuffix alternates
+    // (parol factored the common `IdentifierRef Ystring` prefix
+    // when the bare-identifier `'{' ... '}'` alternate was folded
+    // into the `Ystring '{' ... '}'` form).
+    node.argument = ystring(&m.ystring);
     node
 }
 

--- a/tests/unquoted_strings.rs
+++ b/tests/unquoted_strings.rs
@@ -1,0 +1,25 @@
+// RFC 7950 §6.1.3 — unquoted-string acceptance.
+//
+// `units`, `description`, `organization`, `contact`, `reference` all
+// take a YANG string argument. The spec allows either the quoted or
+// the unquoted form. Before this test landed, libyang's grammar
+// required quotes for everything that went through `Ystring`, which
+// rejected RFC-valid modules. The fixture writes every relevant
+// statement in the bare form; if the parser comes back without
+// errors, the unquoted form is accepted.
+
+use libyang::YangStore;
+
+#[test]
+fn unquoted_string_arguments_accepted() {
+    let mut store = YangStore::new();
+    store.add_path("tests/yang");
+    store
+        .read_with_resolve("unquoted-strings")
+        .expect("unquoted-string YANG must parse");
+    store.identity_resolve();
+    let module = store
+        .find_module("unquoted-strings")
+        .expect("module registered");
+    assert_eq!(module.name, "unquoted-strings");
+}

--- a/tests/yang/unquoted-strings.yang
+++ b/tests/yang/unquoted-strings.yang
@@ -1,0 +1,20 @@
+// RFC 7950 §6.1.3 unquoted-string acceptance test fixture.
+// Every statement here that uses a string argument is intentionally
+// written in the bare-identifier form. A YANG parser that follows
+// the spec must accept all of them.
+module unquoted-strings {
+  yang-version 1;
+  namespace "urn:example:unquoted-strings";
+  prefix us;
+
+  organization example;
+  contact noc;
+  description bare-description;
+  reference rfc7950;
+
+  leaf drain {
+    type uint32;
+    units milliseconds;
+    description scrub;
+  }
+}

--- a/yang.par
+++ b/yang.par
@@ -436,11 +436,6 @@ UnknownStmt
     '{'^
     { TypeStmt
     | DescriptionStmt }
-    '}'^
-    | IdentifierRef Identifier
-    '{'^
-    { TypeStmt
-    | DescriptionStmt }
     '}'^;
 
 LeafListStmt
@@ -734,8 +729,15 @@ DateArg
     : <Revision>/\d{4}-\d{2}-\d{2}/;
 
 // Ystring definition starts here.
+// RFC 7950 §6.1.3 allows unquoted strings as YANG statement arguments
+// (any token not containing whitespace, quotes, ';', '{', '}', or a
+// comment-introducer). For the common case the existing `Identifier`
+// token covers it: `units milliseconds;`, `description foo;`, etc.
+// The `+` concatenation form only applies to quoted strings, so the
+// unquoted alternative is a plain `Identifier`.
 Ystring
-    : BasicString [ '+' Ystring ];
+    : BasicString [ '+' Ystring ]
+    | Identifier;
 
 BasicString
     : DQString


### PR DESCRIPTION
## Summary

- `Ystring` was strictly `BasicString [ '+' Ystring ]` (DQ/SQ only). RFC 7950 §6.1.3 also permits the unquoted-string form everywhere YANG accepts a string — `DefaultStmt` already exercised this via `AsciiNoSemicolon`, but every other `Ystring` consumer (`units`, `error-message`, `presence`, `must`, `path`, `pattern`, `organization`, `contact`, `description`, `reference`, `when`) rejected the bare form, breaking RFC-valid YANG modules.
- `yang.par`: add `| Identifier` to `Ystring` so the bare form is accepted in one place; the `Identifier` regex (`[a-zA-Z_][a-zA-Z0-9_\-\/.:]*`) covers `units milliseconds`, `description foo`, `units bits/sec`, etc. The `+` concatenation form is reserved for the quoted path.
- `yang.par`: `UnknownStmt` had an explicit `IdentifierRef Identifier '{'...'}'` alternate that became redundant — and ambiguous in LL(k) — once `Ystring` subsumes `Identifier`. Folded into the existing `IdentifierRef Ystring '{'...'}'` alternate. parol factors out the shared `IdentifierRef Ystring` prefix.
- `src/nodes/ast.rs`: `Ystring` is now a parol-generated enum; `ystring()` dispatches on `BasicStringYstringOpt` vs `Identifier`. `unknown()` reads `m.ystring` directly because parol factored `IdentifierRef Ystring` out of `UnknownStmt`.

## Test plan

- [x] New `tests/unquoted_strings.rs` + fixture `tests/yang/unquoted-strings.yang` exercise bare `units`, `description`, `organization`, `contact`, `reference` in one module → parses cleanly.
- [x] Full `cargo test` (`augment`, `choice_flatten`, `leafref_path`, `union_inline_arms`, the new `unquoted_strings`) — all green.
- [x] Downstream zebra-rs builds against this checkout via `path = "../../libyang"` and its full 637-test unit suite passes.

Generated with [Claude Code](https://claude.com/claude-code)