### PR TITLE
augment: RFC 7950 §7.17 conformance (stages 1–6)

### DIFF
--- a/src/nodes/ast.rs
+++ b/src/nodes/ast.rs
@@ -257,9 +257,21 @@ fn augment(m: &AugmentStmt) -> AugmentNode {
             AugmentStmtListGroup::ReferenceStmt(m) => {
                 node.reference = Some(ystring(&m.reference_stmt.ystring));
             }
-            AugmentStmtListGroup::WhenStmt(_) => {}
+            AugmentStmtListGroup::CaseStmt(m) => {
+                node.cases.push(case(&m.case_stmt));
+            }
+            AugmentStmtListGroup::ActionStmt(m) => {
+                node.action.push(action(&m.action_stmt));
+            }
+            AugmentStmtListGroup::WhenStmt(m) => {
+                node.when = Some(when(&m.when_stmt));
+            }
+            AugmentStmtListGroup::StatusStmt(m) => {
+                node.status = Some(status(&m.status_stmt));
+            }
+            // if-feature and notification are parsed but not yet
+            // modeled; see AugmentNode's doc comment for the reason.
             AugmentStmtListGroup::IfFeatureStmt(_) => {}
-            AugmentStmtListGroup::StatusStmt(_) => {}
             AugmentStmtListGroup::NotificationStmt(_) => {}
         }
     }

--- a/src/nodes/ast.rs
+++ b/src/nodes/ast.rs
@@ -269,13 +269,61 @@ fn augment(m: &AugmentStmt) -> AugmentNode {
             AugmentStmtListGroup::StatusStmt(m) => {
                 node.status = Some(status(&m.status_stmt));
             }
-            // if-feature and notification are parsed but not yet
-            // modeled; see AugmentNode's doc comment for the reason.
-            AugmentStmtListGroup::IfFeatureStmt(_) => {}
+            AugmentStmtListGroup::IfFeatureStmt(m) => {
+                node.if_feature.push(if_feature(&m.if_feature_stmt));
+            }
+            // notification is parsed but not yet modeled; see
+            // AugmentNode's doc comment for the reason.
             AugmentStmtListGroup::NotificationStmt(_) => {}
         }
     }
     node
+}
+
+/// Convert an `if-feature` statement's expression (RFC 7950 §7.20.2)
+/// into the structured `IfFeatureExprNode` tree. Reusable by any
+/// statement that accepts `if-feature`.
+fn if_feature(m: &IfFeatureStmt) -> IfFeatureNode {
+    IfFeatureNode::new(if_feature_expr(&m.if_feature_expr_str.if_feature_expr))
+}
+
+fn if_feature_expr(e: &IfFeatureExpr) -> IfFeatureExprNode {
+    let term = if_feature_term(&e.if_feature_term);
+    match &e.if_feature_expr_opt {
+        // `term or expr` — `or` is right-associative as written.
+        Some(opt) => IfFeatureExprNode::Or(
+            Box::new(term),
+            Box::new(if_feature_expr(&opt.if_feature_expr)),
+        ),
+        None => term,
+    }
+}
+
+fn if_feature_term(t: &IfFeatureTerm) -> IfFeatureExprNode {
+    let factor = if_feature_factor(&t.if_feature_factor);
+    match &t.if_feature_term_opt {
+        // `factor and term` — binds tighter than `or`.
+        Some(opt) => IfFeatureExprNode::And(
+            Box::new(factor),
+            Box::new(if_feature_term(&opt.if_feature_term)),
+        ),
+        None => factor,
+    }
+}
+
+fn if_feature_factor(f: &IfFeatureFactor) -> IfFeatureExprNode {
+    match f {
+        IfFeatureFactor::NotIfFeatureFactor(m) => {
+            IfFeatureExprNode::Not(Box::new(if_feature_factor(&m.if_feature_factor)))
+        }
+        IfFeatureFactor::LParenIfFeatureExprRParen(m) => if_feature_expr(&m.if_feature_expr),
+        IfFeatureFactor::Identifier(m) => {
+            IfFeatureExprNode::Feature(m.identifier.identifier.text().to_string())
+        }
+        IfFeatureFactor::DoubleQuotationIdentifierDoubleQuotation(m) => {
+            IfFeatureExprNode::Feature(m.identifier.identifier.text().to_string())
+        }
+    }
 }
 
 fn datadef(node: &mut DatadefNode, m: &DataDefStmt) {

--- a/src/nodes/ast.rs
+++ b/src/nodes/ast.rs
@@ -1165,7 +1165,9 @@ fn uses(m: &UsesStmt) -> UsesNode {
                     node.reference = Some(ystring(&m.reference_stmt.ystring));
                 }
                 UsesStmtListGroup::RefineStmt(_m) => {}
-                UsesStmtListGroup::AugmentStmt(_m) => {}
+                UsesStmtListGroup::AugmentStmt(m) => {
+                    node.augment.push(augment(&m.augment_stmt));
+                }
             }
         }
     }

--- a/src/nodes/node.rs
+++ b/src/nodes/node.rs
@@ -678,11 +678,25 @@ pub struct GroupingNode {
 /// string (e.g. "/a:root/a:inner/b:leaf") as written in the module;
 /// the entry-building pass splits the segments and resolves prefixes
 /// against the augmenting module's imports.
+///
+/// `when` carries the conditional that, per §7.17, MUST guard an
+/// augment that adds mandatory config to another module. `cases` and
+/// `action` hold the `case`/`action` substatements allowed when the
+/// target is a choice (case) or a container/list (action).
+///
+/// Not yet modeled (stage two): `if-feature` (its argument is a
+/// boolean feature expression that nothing in this crate captures
+/// yet) and `notification` (no notification node type exists in the
+/// AST at all). Both are parsed by the grammar and currently dropped.
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct AugmentNode {
     pub target: String,
     pub description: Option<String>,
     pub reference: Option<String>,
+    pub when: Option<WhenNode>,
+    pub status: Option<StatusNode>,
+    pub cases: Vec<CaseNode>,
+    pub action: Vec<ActionNode>,
     pub d: DatadefNode,
 }
 

--- a/src/nodes/node.rs
+++ b/src/nodes/node.rs
@@ -651,6 +651,11 @@ pub struct UsesNode {
     pub reference: Option<String>,
     pub when: Option<WhenNode>,
     pub status: Option<StatusNode>,
+    /// `augment` substatements (RFC 7950 §7.17, descendant form) that
+    /// add nodes to the grouping this `uses` instantiates. Applied
+    /// after the grouping is expanded, relative to the instantiation
+    /// point.
+    pub augment: Vec<AugmentNode>,
     pub d: DatadefNode,
 }
 

--- a/src/nodes/node.rs
+++ b/src/nodes/node.rs
@@ -323,14 +323,29 @@ impl WhenNode {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Default)]
+/// A parsed `if-feature` boolean expression (RFC 7950 §7.20.2): a
+/// feature reference (possibly prefixed), a negation, or an `and`/`or`
+/// of subexpressions. Parentheses in the source collapse into the tree
+/// shape and are not represented explicitly.
+#[derive(Debug, PartialEq, Clone)]
+pub enum IfFeatureExprNode {
+    Feature(String),
+    Not(Box<IfFeatureExprNode>),
+    And(Box<IfFeatureExprNode>, Box<IfFeatureExprNode>),
+    Or(Box<IfFeatureExprNode>, Box<IfFeatureExprNode>),
+}
+
+/// One `if-feature` statement, carrying its parsed expression. The
+/// expression is captured but not yet evaluated — there is no
+/// feature-support context in the entry-building pass.
+#[derive(Debug, PartialEq, Clone)]
 pub struct IfFeatureNode {
-    pub name: String,
+    pub expr: IfFeatureExprNode,
 }
 
 impl IfFeatureNode {
-    pub fn new(name: String) -> Self {
-        Self { name }
+    pub fn new(expr: IfFeatureExprNode) -> Self {
+        Self { expr }
     }
 }
 
@@ -688,11 +703,11 @@ pub struct GroupingNode {
 /// augment that adds mandatory config to another module. `cases` and
 /// `action` hold the `case`/`action` substatements allowed when the
 /// target is a choice (case) or a container/list (action).
+/// `if_feature` holds the parsed `if-feature` expressions (captured but
+/// not yet evaluated — there is no feature-support context).
 ///
-/// Not yet modeled (stage two): `if-feature` (its argument is a
-/// boolean feature expression that nothing in this crate captures
-/// yet) and `notification` (no notification node type exists in the
-/// AST at all). Both are parsed by the grammar and currently dropped.
+/// Not yet modeled: `notification` (no notification node type exists in
+/// the AST at all). It is parsed by the grammar and currently dropped.
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct AugmentNode {
     pub target: String,
@@ -700,6 +715,7 @@ pub struct AugmentNode {
     pub reference: Option<String>,
     pub when: Option<WhenNode>,
     pub status: Option<StatusNode>,
+    pub if_feature: Vec<IfFeatureNode>,
     pub cases: Vec<CaseNode>,
     pub action: Vec<ActionNode>,
     pub d: DatadefNode,

--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -271,6 +271,14 @@ where
     if augment_target_module(top, &aug.target) != root.name {
         return;
     }
+    // RFC 7950 §7.17: a top-level augment's target is an
+    // absolute-schema-nodeid (leading '/').
+    if !aug.target.starts_with('/') {
+        eprintln!(
+            "augment: top-level target \"{}\" must use the absolute form (leading '/')",
+            aug.target
+        );
+    }
     resolve_and_inject(top, store, root, aug, "augment");
 }
 
@@ -298,6 +306,14 @@ fn apply_uses_augment<T>(top: &T, store: &YangStore, ent: Rc<Entry>, aug: &Augme
 where
     T: ModuleCommon,
 {
+    // RFC 7950 §7.17: a uses-substatement augment's target is a
+    // descendant-schema-nodeid (no leading '/').
+    if aug.target.starts_with('/') {
+        eprintln!(
+            "uses augment: target \"{}\" must use the descendant form (no leading '/')",
+            aug.target
+        );
+    }
     resolve_and_inject(top, store, ent, aug, "uses augment");
 }
 
@@ -334,9 +350,46 @@ fn inject_augment_body<T>(top: &T, store: &YangStore, current: Rc<Entry>, aug: &
 where
     T: ModuleCommon,
 {
+    // RFC 7950 §7.17: data nodes and actions may only be added to a
+    // container/list/choice/case/input/output/notification — never to a
+    // leaf or leaf-list. Resolution lands on a leaf only when the
+    // augment is malformed.
+    if current.is_leaf_entry() {
+        eprintln!(
+            "augment: cannot add nodes to leaf target \"{}\" ({})",
+            current.name, aug.target
+        );
+        return;
+    }
+
+    // Snapshot existing child names so duplicates the augment introduces
+    // can be rejected afterwards (RFC 7950 §7.17: an augment MUST NOT add
+    // a node with the same name as one already present in the target).
+    let existing: Vec<String> = current
+        .dir
+        .borrow()
+        .iter()
+        .map(|e| e.name.clone())
+        .collect();
+    let before_len = existing.len();
+
     datadef_entry(top, store, &aug.d, current.clone());
     for a in aug.action.iter() {
         action_entry(top, store, a, current.clone());
+    }
+
+    let mut dir = current.dir.borrow_mut();
+    let mut i = before_len;
+    while i < dir.len() {
+        if existing.contains(&dir[i].name) {
+            eprintln!(
+                "augment: node \"{}\" already exists in target \"{}\"; not added",
+                dir[i].name, current.name
+            );
+            dir.remove(i);
+        } else {
+            i += 1;
+        }
     }
 }
 

--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -205,19 +205,42 @@ pub fn to_entry(store: &YangStore, module: &ModuleNode) -> Rc<Entry> {
     entry.clone()
 }
 
-/// Walk `aug.target` from `root` and inject `aug.d`'s children at
-/// the resolved node. Silently no-ops if the target cannot be found
-/// (malformed augment, missing prefix binding, etc.).
-fn apply_augment<T>(top: &T, store: &YangStore, root: Rc<Entry>, aug: &AugmentNode)
+/// Resolve the name of the module whose schema tree `target` roots
+/// in, as seen from the augmenting module `top`. The leading segment
+/// of an absolute schema-node-identifier carries the prefix that
+/// binds the rest of the path to a module (RFC 7950 §6.5): the
+/// augmenting module's own prefix maps to its own name, an imported
+/// prefix maps to the imported module's name, and a bare (prefixless)
+/// first segment defaults to the augmenting module itself.
+fn augment_target_module<T>(top: &T, target: &str) -> String
 where
     T: ModuleCommon,
 {
+    let first = target.split('/').find(|s| !s.is_empty()).unwrap_or("");
+    match first.split_once(':') {
+        Some((prefix, _)) => {
+            if Some(prefix) == top.get_prefix() {
+                top.get_name().to_string()
+            } else {
+                // Maps an imported prefix to its module name, or
+                // returns the prefix unchanged when it binds to
+                // nothing — in which case the caller's module-name
+                // comparison fails and the augment is skipped.
+                prefix_resolve(top, prefix.to_string())
+            }
+        }
+        None => top.get_name().to_string(),
+    }
+}
+
+/// Walk `target` from `root`, matching each `[prefix:]name` segment
+/// by its bare name against the Entry tree (the tree carries no
+/// per-node namespace, and names are effectively unique within a
+/// container). Returns the resolved entry, or the first segment that
+/// did not match so callers can report where the path broke.
+fn resolve_target(root: Rc<Entry>, target: &str) -> Result<Rc<Entry>, String> {
     let mut current = root;
-    for seg in aug.target.split('/').filter(|s| !s.is_empty()) {
-        // YANG schema-node identifier segments are `[prefix:]name`.
-        // We match on the bare name against the Entry tree — the
-        // tree doesn't carry per-node namespace metadata, and names
-        // are effectively globally unique within their container.
+    for seg in target.split('/').filter(|s| !s.is_empty()) {
         let name = seg.rsplit(':').next().unwrap_or(seg);
         let next = current
             .dir
@@ -227,9 +250,42 @@ where
             .cloned();
         match next {
             Some(e) => current = e,
-            None => return,
+            None => return Err(seg.to_string()),
         }
     }
+    Ok(current)
+}
+
+/// Walk `aug.target` from `root` and inject `aug.d`'s children at the
+/// resolved node.
+///
+/// `to_entry` applies every loaded module's augments against the tree
+/// currently being built, so first check that this augment actually
+/// targets this tree's module (`root.name`) before touching it; that
+/// both prevents an augment from bleeding into an unrelated module
+/// that happens to share a node name and keeps the not-found
+/// diagnostic below meaningful. A relevant augment whose path does
+/// not resolve is a real error, so report it instead of silently
+/// no-oping.
+fn apply_augment<T>(top: &T, store: &YangStore, root: Rc<Entry>, aug: &AugmentNode)
+where
+    T: ModuleCommon,
+{
+    if augment_target_module(top, &aug.target) != root.name {
+        return;
+    }
+    let current = match resolve_target(root, &aug.target) {
+        Ok(current) => current,
+        Err(seg) => {
+            eprintln!(
+                "augment: in module {}, target \"{}\" not found (no node matching \"{}\")",
+                top.get_name(),
+                aug.target,
+                seg
+            );
+            return;
+        }
+    };
     datadef_entry(top, store, &aug.d, current);
 }
 
@@ -261,6 +317,8 @@ where
 }
 
 pub trait ModuleCommon {
+    fn get_name(&self) -> &str;
+    fn get_prefix(&self) -> Option<&str>;
     fn get_identity(&self) -> &Vec<IdentityNode>;
     fn get_identities_mut(&mut self) -> &mut HashMap<String, Vec<String>>;
     fn get_include(&self) -> &Vec<IncludeNode>;
@@ -757,6 +815,14 @@ where
 }
 
 impl ModuleCommon for ModuleNode {
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    fn get_prefix(&self) -> Option<&str> {
+        self.prefix.as_deref()
+    }
+
     fn get_identity(&self) -> &Vec<IdentityNode> {
         &self.identity
     }
@@ -787,6 +853,16 @@ impl ModuleCommon for ModuleNode {
 }
 
 impl ModuleCommon for SubmoduleNode {
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    fn get_prefix(&self) -> Option<&str> {
+        // A submodule has no prefix of its own; per RFC 7950 §7.2.2 it
+        // shares the prefix of the module it belongs to.
+        self.belongs_to.as_ref().and_then(|b| b.prefix.as_deref())
+    }
+
     fn get_identity(&self) -> &Vec<IdentityNode> {
         &self.identity
     }
@@ -813,5 +889,36 @@ impl ModuleCommon for SubmoduleNode {
 
     fn get_d(&self) -> &DatadefNode {
         &self.d
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dir(name: &str) -> Rc<Entry> {
+        Rc::new(Entry::new_dir(name.to_string()))
+    }
+
+    #[test]
+    fn resolve_target_walks_prefixed_path_by_bare_name() {
+        let root = dir("m");
+        let top = dir("top");
+        let item = dir("item");
+        top.dir.borrow_mut().push(item);
+        root.dir.borrow_mut().push(top);
+
+        // Each `prefix:name` segment is matched on its bare name.
+        let found = resolve_target(root, "/a:top/a:item").expect("resolved");
+        assert_eq!(found.name, "item");
+    }
+
+    #[test]
+    fn resolve_target_reports_first_missing_segment() {
+        let root = dir("m");
+        root.dir.borrow_mut().push(dir("top"));
+
+        let err = resolve_target(root, "/a:top/a:missing").unwrap_err();
+        assert_eq!(err, "a:missing");
     }
 }

--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -256,17 +256,14 @@ fn resolve_target(root: Rc<Entry>, target: &str) -> Result<Rc<Entry>, String> {
     Ok(current)
 }
 
-/// Walk `aug.target` from `root` and inject `aug.d`'s children at the
-/// resolved node.
+/// Apply a top-level `augment` against the tree rooted at `root`.
 ///
 /// `to_entry` applies every loaded module's augments against the tree
 /// currently being built, so first check that this augment actually
 /// targets this tree's module (`root.name`) before touching it; that
 /// both prevents an augment from bleeding into an unrelated module
 /// that happens to share a node name and keeps the not-found
-/// diagnostic below meaningful. A relevant augment whose path does
-/// not resolve is a real error, so report it instead of silently
-/// no-oping.
+/// diagnostic meaningful.
 fn apply_augment<T>(top: &T, store: &YangStore, root: Rc<Entry>, aug: &AugmentNode)
 where
     T: ModuleCommon,
@@ -274,19 +271,7 @@ where
     if augment_target_module(top, &aug.target) != root.name {
         return;
     }
-    let current = match resolve_target(root, &aug.target) {
-        Ok(current) => current,
-        Err(seg) => {
-            eprintln!(
-                "augment: in module {}, target \"{}\" not found (no node matching \"{}\")",
-                top.get_name(),
-                aug.target,
-                seg
-            );
-            return;
-        }
-    };
-    datadef_entry(top, store, &aug.d, current);
+    resolve_and_inject(top, store, root, aug, "augment");
 }
 
 /// Expand a `uses` into `ent`: instantiate the referenced grouping,
@@ -304,7 +289,7 @@ where
     }
 }
 
-/// Inject a `uses`-substatement augment (RFC 7950 §7.17, descendant
+/// Apply a `uses`-substatement augment (RFC 7950 §7.17, descendant
 /// form). The target path is relative to `ent`, the point where the
 /// grouping was just expanded, so resolve from there directly. Unlike
 /// a top-level augment there is no cross-module targeting to gate on —
@@ -313,14 +298,154 @@ fn apply_uses_augment<T>(top: &T, store: &YangStore, ent: Rc<Entry>, aug: &Augme
 where
     T: ModuleCommon,
 {
-    match resolve_target(ent, &aug.target) {
-        Ok(current) => datadef_entry(top, store, &aug.d, current),
-        Err(seg) => eprintln!(
-            "uses augment: in module {}, target \"{}\" not found (no node matching \"{}\")",
-            top.get_name(),
-            aug.target,
-            seg
-        ),
+    resolve_and_inject(top, store, ent, aug, "uses augment");
+}
+
+/// Resolve `aug.target` from `root` and inject the augment body.
+/// Shared by top-level and uses augments (`kind` only labels the
+/// diagnostic). If the path resolves to a data node, inject there; if
+/// the final segment instead names a choice (choices are flattened and
+/// not addressable as entries), add the augment's cases to that choice.
+fn resolve_and_inject<T>(top: &T, store: &YangStore, root: Rc<Entry>, aug: &AugmentNode, kind: &str)
+where
+    T: ModuleCommon,
+{
+    match resolve_target(root.clone(), &aug.target) {
+        Ok(current) => inject_augment_body(top, store, current, aug),
+        Err(seg) => {
+            if !augment_into_choice(top, store, root, aug) {
+                eprintln!(
+                    "{kind}: in module {}, target \"{}\" not found (no node matching \"{}\")",
+                    top.get_name(),
+                    aug.target,
+                    seg
+                );
+            }
+        }
+    }
+}
+
+/// Inject an augment body into an already-resolved data node: its
+/// data-def children (RFC 7950 §7.17) and any `action` substatements
+/// (valid when the target is a container or list). Explicit `case`
+/// substatements are handled separately by `augment_into_choice` since
+/// they only apply to choice targets, which are not data nodes.
+fn inject_augment_body<T>(top: &T, store: &YangStore, current: Rc<Entry>, aug: &AugmentNode)
+where
+    T: ModuleCommon,
+{
+    datadef_entry(top, store, &aug.d, current.clone());
+    for a in aug.action.iter() {
+        action_entry(top, store, a, current.clone());
+    }
+}
+
+/// Handle an augment whose target is a choice. A choice node is not an
+/// addressable entry — `choice_entry` flattens each case's children
+/// into the choice's parent, tagged with the choice/case names — so
+/// resolve the parent (every segment but the last) and treat the final
+/// segment as the choice name. The choice is only detectable once it
+/// already carries a case, so an empty choice cannot be augmented this
+/// way (a known limitation). Returns true if it handled the augment.
+fn augment_into_choice<T>(top: &T, store: &YangStore, root: Rc<Entry>, aug: &AugmentNode) -> bool
+where
+    T: ModuleCommon,
+{
+    let segs: Vec<&str> = aug.target.split('/').filter(|s| !s.is_empty()).collect();
+    let Some((last, parents)) = segs.split_last() else {
+        return false;
+    };
+    let choice_name = last.rsplit(':').next().unwrap_or(last);
+
+    let mut parent = root;
+    for seg in parents {
+        let name = seg.rsplit(':').next().unwrap_or(seg);
+        let next = parent.dir.borrow().iter().find(|e| e.name == name).cloned();
+        match next {
+            Some(e) => parent = e,
+            None => return false,
+        }
+    }
+
+    let is_choice = parent
+        .dir
+        .borrow()
+        .iter()
+        .any(|c| c.choice.borrow().as_deref() == Some(choice_name));
+    if !is_choice {
+        return false;
+    }
+
+    // Explicit `case` substatements.
+    for case in aug.cases.iter() {
+        inject_case(top, store, parent.clone(), choice_name, &case.name, &case.d);
+    }
+    // Shorthand cases: each direct data node forms its own case named
+    // after the node (RFC 7950 §7.9.2).
+    for c in aug.d.container.iter() {
+        inject_case_node(parent.clone(), choice_name, &c.name, |e| {
+            container_entry(top, store, c, e)
+        });
+    }
+    for leaf in aug.d.leaf.iter() {
+        inject_case_node(parent.clone(), choice_name, &leaf.name, |e| {
+            leaf_entry(top, store, leaf, e)
+        });
+    }
+    for list in aug.d.list.iter() {
+        inject_case_node(parent.clone(), choice_name, &list.name, |e| {
+            list_entry(top, store, list, e)
+        });
+    }
+    for leaf_list in aug.d.leaf_list.iter() {
+        inject_case_node(parent.clone(), choice_name, &leaf_list.name, |e| {
+            leaf_list_entry(top, store, leaf_list, e)
+        });
+    }
+    true
+}
+
+/// Inject an explicit `case`'s data-def children into `ent` (the
+/// choice's parent) and tag the newly added entries with the choice
+/// and case names — the flattened representation used throughout for
+/// choice/case membership.
+fn inject_case<T>(
+    top: &T,
+    store: &YangStore,
+    ent: Rc<Entry>,
+    choice_name: &str,
+    case_name: &str,
+    d: &DatadefNode,
+) where
+    T: ModuleCommon,
+{
+    let before = ent.dir.borrow().len();
+    datadef_entry(top, store, d, ent.clone());
+    tag_case_children(&ent, before, choice_name, case_name);
+}
+
+/// Inject a single shorthand-case node via `build` and tag the entries
+/// it added with the choice name and the node's own name (the implicit
+/// case name for a shorthand case).
+fn inject_case_node<F>(ent: Rc<Entry>, choice_name: &str, case_name: &str, build: F)
+where
+    F: FnOnce(Rc<Entry>),
+{
+    let before = ent.dir.borrow().len();
+    build(ent.clone());
+    tag_case_children(&ent, before, choice_name, case_name);
+}
+
+/// Tag entries appended to `ent.dir` at or after index `before` with
+/// the given choice/case names, leaving any already tagged by a nested
+/// choice recursion untouched (innermost wins).
+fn tag_case_children(ent: &Rc<Entry>, before: usize, choice_name: &str, case_name: &str) {
+    let dir = ent.dir.borrow();
+    for child in dir[before..].iter() {
+        if child.choice.borrow().is_none() {
+            *child.choice.borrow_mut() = Some(choice_name.to_string());
+            *child.case.borrow_mut() = Some(case_name.to_string());
+        }
     }
 }
 
@@ -679,42 +804,10 @@ where
     // nodes appear in the data tree — only the case's direct data
     // children do. We flatten each case's children into the choice's
     // parent `ent.dir` and tag each added entry with (choice, case)
-    // metadata so consumers can enforce mutual exclusion later.
-    let choice_name = c.name.clone();
-
+    // metadata so consumers can enforce mutual exclusion later. The
+    // same flattening is reused by `augment_into_choice`.
     for case in c.cases.iter() {
-        let case_name = case.name.clone();
-        let len_before = ent.dir.borrow().len();
-
-        for uses in case.d.uses.iter() {
-            uses_entry(top, store, uses, ent.clone());
-        }
-        for cnode in case.d.container.iter() {
-            container_entry(top, store, cnode, ent.clone());
-        }
-        for leaf in case.d.leaf.iter() {
-            leaf_entry(top, store, leaf, ent.clone());
-        }
-        for list in case.d.list.iter() {
-            list_entry(top, store, list, ent.clone());
-        }
-        for leaf_list in case.d.leaf_list.iter() {
-            leaf_list_entry(top, store, leaf_list, ent.clone());
-        }
-        for nested in case.d.choice.iter() {
-            choice_entry(top, store, nested, ent.clone());
-        }
-
-        // Tag the newly added entries. Skip any already tagged by a
-        // nested `choice_entry` recursion — the innermost choice/case
-        // wins (outer-nesting metadata is not currently represented).
-        let dir = ent.dir.borrow();
-        for child in dir[len_before..].iter() {
-            if child.choice.borrow().is_none() {
-                *child.choice.borrow_mut() = Some(choice_name.clone());
-                *child.case.borrow_mut() = Some(case_name.clone());
-            }
-        }
+        inject_case(top, store, ent.clone(), &c.name, &case.name, &case.d);
     }
 }
 

--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -50,6 +50,12 @@ pub struct Entry {
     // here with the choice and case names.
     pub choice: RefCell<Option<String>>,
     pub case: RefCell<Option<String>>,
+
+    // Names of `choice` nodes defined directly under this entry. A
+    // choice is otherwise invisible in the flattened tree (only its
+    // cases' children appear), so recording the names lets an augment
+    // target a choice — including one that has no cases yet.
+    pub choice_defs: RefCell<Vec<String>>,
 }
 
 impl Entry {
@@ -397,9 +403,10 @@ where
 /// addressable entry — `choice_entry` flattens each case's children
 /// into the choice's parent, tagged with the choice/case names — so
 /// resolve the parent (every segment but the last) and treat the final
-/// segment as the choice name. The choice is only detectable once it
-/// already carries a case, so an empty choice cannot be augmented this
-/// way (a known limitation). Returns true if it handled the augment.
+/// segment as the choice name. The choice is recognised via the
+/// parent's recorded `choice_defs`, which lists every choice defined
+/// there whether or not it has cases. Returns true if it handled the
+/// augment.
 fn augment_into_choice<T>(top: &T, store: &YangStore, root: Rc<Entry>, aug: &AugmentNode) -> bool
 where
     T: ModuleCommon,
@@ -420,11 +427,7 @@ where
         }
     }
 
-    let is_choice = parent
-        .dir
-        .borrow()
-        .iter()
-        .any(|c| c.choice.borrow().as_deref() == Some(choice_name));
+    let is_choice = parent.choice_defs.borrow().iter().any(|n| n == choice_name);
     if !is_choice {
         return false;
     }
@@ -852,6 +855,10 @@ where
             return;
         }
     }
+
+    // Record the choice name on its parent so it stays addressable for
+    // augments even before (or without) any case contributing children.
+    ent.choice_defs.borrow_mut().push(c.name.clone());
 
     // Per RFC 7950 §7.9.2, neither the `choice` node nor its `case`
     // nodes appear in the data tree — only the case's direct data

--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -289,6 +289,41 @@ where
     datadef_entry(top, store, &aug.d, current);
 }
 
+/// Expand a `uses` into `ent`: instantiate the referenced grouping,
+/// then apply any uses-substatement augments. Every site that expands
+/// a `uses` (module/container/list bodies, choice cases, rpc/action
+/// input and output) goes through here so uses-augments are applied
+/// consistently.
+fn uses_entry<T>(top: &T, store: &YangStore, uses: &UsesNode, ent: Rc<Entry>)
+where
+    T: ModuleCommon,
+{
+    group_resolve(top, store, &uses.name, ent.clone());
+    for aug in uses.augment.iter() {
+        apply_uses_augment(top, store, ent.clone(), aug);
+    }
+}
+
+/// Inject a `uses`-substatement augment (RFC 7950 §7.17, descendant
+/// form). The target path is relative to `ent`, the point where the
+/// grouping was just expanded, so resolve from there directly. Unlike
+/// a top-level augment there is no cross-module targeting to gate on —
+/// the augment only ever reaches nodes the grouping contributed.
+fn apply_uses_augment<T>(top: &T, store: &YangStore, ent: Rc<Entry>, aug: &AugmentNode)
+where
+    T: ModuleCommon,
+{
+    match resolve_target(ent, &aug.target) {
+        Ok(current) => datadef_entry(top, store, &aug.d, current),
+        Err(seg) => eprintln!(
+            "uses augment: in module {}, target \"{}\" not found (no node matching \"{}\")",
+            top.get_name(),
+            aug.target,
+            seg
+        ),
+    }
+}
+
 /// Process a DatadefNode's children (uses, container, leaf, list,
 /// leaf-list, choice) into `ent.dir`. Shared between groupings and
 /// augments.
@@ -297,7 +332,7 @@ where
     T: ModuleCommon,
 {
     for uses in d.uses.iter() {
-        group_resolve(top, store, &uses.name, ent.clone());
+        uses_entry(top, store, uses, ent.clone());
     }
     for c in d.container.iter() {
         container_entry(top, store, c, ent.clone());
@@ -572,7 +607,7 @@ where
 
         // Process input data definitions
         for uses in input.d.uses.iter() {
-            group_resolve(top, store, &uses.name, input_rc.clone());
+            uses_entry(top, store, uses, input_rc.clone());
         }
         for c in input.d.container.iter() {
             container_entry(top, store, c, input_rc.clone());
@@ -604,7 +639,7 @@ where
 
         // Process output data definitions
         for uses in output.d.uses.iter() {
-            group_resolve(top, store, &uses.name, output_rc.clone());
+            uses_entry(top, store, uses, output_rc.clone());
         }
         for c in output.d.container.iter() {
             container_entry(top, store, c, output_rc.clone());
@@ -652,7 +687,7 @@ where
         let len_before = ent.dir.borrow().len();
 
         for uses in case.d.uses.iter() {
-            group_resolve(top, store, &uses.name, ent.clone());
+            uses_entry(top, store, uses, ent.clone());
         }
         for cnode in case.d.container.iter() {
             container_entry(top, store, cnode, ent.clone());
@@ -700,7 +735,7 @@ where
     let rc = Rc::new(e);
 
     for uses in c.d.uses.iter() {
-        group_resolve(top, store, &uses.name, rc.clone());
+        uses_entry(top, store, uses, rc.clone());
     }
     for c in c.d.container.iter() {
         container_entry(top, store, c, rc.clone());
@@ -746,7 +781,7 @@ where
     let rc = Rc::new(e);
 
     for uses in l.d.uses.iter() {
-        group_resolve(top, store, &uses.name, rc.clone());
+        uses_entry(top, store, uses, rc.clone());
     }
     for c in l.d.container.iter() {
         container_entry(top, store, c, rc.clone());

--- a/tests/augment.rs
+++ b/tests/augment.rs
@@ -34,6 +34,10 @@ fn find_child(ent: &Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
     ent.dir.borrow().iter().find(|e| e.name == name).cloned()
 }
 
+fn count_children(ent: &Rc<Entry>, name: &str) -> usize {
+    ent.dir.borrow().iter().filter(|e| e.name == name).count()
+}
+
 #[test]
 fn augment_injects_leaf_into_cross_module_target() {
     // tests/yang/augment-target.yang — base module.
@@ -150,5 +154,37 @@ fn augment_adds_case_to_choice() {
         c.case.borrow().as_deref(),
         Some("extra"),
         "leaf should be tagged with the case name"
+    );
+}
+
+#[test]
+fn augment_rejects_duplicate_node() {
+    // tests/yang/augment-dup.yang augments container `box` with a `base`
+    // leaf that already exists plus a new `fresh` leaf. The duplicate
+    // must be rejected; the new node must be added.
+    let root = load("augment-dup", "tests/yang");
+    let box_ = find_child(&root, "box").expect("box container");
+    assert_eq!(
+        count_children(&box_, "base"),
+        1,
+        "duplicate `base` should not be added a second time"
+    );
+    assert!(
+        find_child(&box_, "fresh").is_some(),
+        "non-duplicate `fresh` should still be added"
+    );
+}
+
+#[test]
+fn augment_rejects_leaf_target() {
+    // tests/yang/augment-leaf-target.yang targets the leaf `box/target`,
+    // which is invalid. Nothing should be injected under the leaf.
+    let root = load("augment-leaf-target", "tests/yang");
+    let box_ = find_child(&root, "box").expect("box container");
+    let target = find_child(&box_, "target").expect("target leaf");
+    assert!(target.is_leaf(), "target should be a leaf");
+    assert!(
+        find_child(&target, "nope").is_none(),
+        "nothing should be added under a leaf target"
     );
 }

--- a/tests/augment.rs
+++ b/tests/augment.rs
@@ -5,7 +5,7 @@
 // /base:root/base:item with a new leaf `badge`. After to_entry, the
 // badge leaf should appear under the item list's dir.
 
-use libyang::{AugmentNode, Entry, YangStore, to_entry};
+use libyang::{AugmentNode, Entry, IfFeatureExprNode, YangStore, to_entry};
 use std::rc::Rc;
 
 fn load(name: &str, yang_dir: &str) -> Rc<Entry> {
@@ -187,6 +187,29 @@ fn augment_rejects_leaf_target() {
         find_child(&target, "nope").is_none(),
         "nothing should be added under a leaf target"
     );
+}
+
+#[test]
+fn augment_captures_if_feature_expression() {
+    // tests/yang/augment-iffeature.yang carries
+    // `if-feature "a and (b or not c)"`, which should parse to
+    // And(a, Or(b, Not(c))) — `and` binds tighter than `or`, and the
+    // parentheses fold into the tree.
+    use IfFeatureExprNode::{And, Feature, Not, Or};
+
+    let augments = augments_of("augment-iffeature", "tests/yang");
+    assert_eq!(augments.len(), 1);
+    let if_features = &augments[0].if_feature;
+    assert_eq!(if_features.len(), 1, "one if-feature statement expected");
+
+    let expected = And(
+        Box::new(Feature("a".to_string())),
+        Box::new(Or(
+            Box::new(Feature("b".to_string())),
+            Box::new(Not(Box::new(Feature("c".to_string())))),
+        )),
+    );
+    assert_eq!(if_features[0].expr, expected);
 }
 
 #[test]

--- a/tests/augment.rs
+++ b/tests/augment.rs
@@ -188,3 +188,16 @@ fn augment_rejects_leaf_target() {
         "nothing should be added under a leaf target"
     );
 }
+
+#[test]
+fn augment_adds_case_to_empty_choice() {
+    // tests/yang/augment-empty-choice.yang augments a choice that has no
+    // cases of its own. The choice is recorded on `top`, so the
+    // augment's case leaf is still injected and tagged.
+    let root = load("augment-empty-choice", "tests/yang");
+    let top = find_child(&root, "top").expect("top container");
+    let v = find_child(&top, "v").expect("augmented case leaf present");
+    assert!(v.is_leaf(), "augmented node should be a leaf");
+    assert_eq!(v.choice.borrow().as_deref(), Some("sel"));
+    assert_eq!(v.case.borrow().as_deref(), Some("only"));
+}

--- a/tests/augment.rs
+++ b/tests/augment.rs
@@ -115,3 +115,40 @@ fn uses_augment_injects_into_grouping_subtree() {
     let added = find_child(&box_, "added").expect("uses-augment leaf present");
     assert!(added.is_leaf(), "augmented node should be a leaf");
 }
+
+#[test]
+fn augment_adds_action_to_container() {
+    // tests/yang/augment-action.yang augments container `box` with an
+    // `action ping;`. The action should appear as an action entry.
+    let root = load("augment-action", "tests/yang");
+    let box_ = find_child(&root, "box").expect("box container");
+    let ping = find_child(&box_, "ping").expect("augmented action present");
+    assert!(ping.is_action(), "augmented node should be an action");
+}
+
+#[test]
+fn augment_adds_case_to_choice() {
+    // tests/yang/augment-choice.yang augments choice `sel` (in `top`)
+    // with `case extra { leaf c; }`. The case's leaf is flattened into
+    // `top` and tagged with the choice/case names, alongside the
+    // pre-existing `base` case's leaf.
+    let root = load("augment-choice", "tests/yang");
+    let top = find_child(&root, "top").expect("top container");
+
+    assert!(
+        find_child(&top, "b").is_some(),
+        "pre-existing case leaf should survive"
+    );
+    let c = find_child(&top, "c").expect("augmented case leaf present");
+    assert!(c.is_leaf(), "augmented node should be a leaf");
+    assert_eq!(
+        c.choice.borrow().as_deref(),
+        Some("sel"),
+        "leaf should be tagged with the choice name"
+    );
+    assert_eq!(
+        c.case.borrow().as_deref(),
+        Some("extra"),
+        "leaf should be tagged with the case name"
+    );
+}

--- a/tests/augment.rs
+++ b/tests/augment.rs
@@ -5,7 +5,7 @@
 // /base:root/base:item with a new leaf `badge`. After to_entry, the
 // badge leaf should appear under the item list's dir.
 
-use libyang::{Entry, YangStore, to_entry};
+use libyang::{AugmentNode, Entry, YangStore, to_entry};
 use std::rc::Rc;
 
 fn load(name: &str, yang_dir: &str) -> Rc<Entry> {
@@ -15,6 +15,19 @@ fn load(name: &str, yang_dir: &str) -> Rc<Entry> {
     store.identity_resolve();
     let module = store.find_module(name).expect("module found");
     to_entry(&store, module)
+}
+
+// Parse a module and return a clone of its top-level augment list so
+// tests can assert on the substatements the AST builder captured.
+fn augments_of(name: &str, yang_dir: &str) -> Vec<AugmentNode> {
+    let mut store = YangStore::new();
+    store.add_path(yang_dir);
+    store.read_with_resolve(name).expect("parse / resolve");
+    store
+        .find_module(name)
+        .expect("module found")
+        .augment
+        .clone()
 }
 
 fn find_child(ent: &Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
@@ -46,4 +59,42 @@ fn augment_injects_leaf_into_cross_module_target() {
         "augmented node should be a leaf, got {:?}",
         badge.kind
     );
+}
+
+#[test]
+fn augment_captures_when_status_action_and_case() {
+    // tests/yang/augment-substmts.yang exercises the substatements the
+    // AST builder used to silently drop: when, status, action (target
+    // is a container) and an explicit case (target is a choice).
+    let augments = augments_of("augment-substmts", "tests/yang");
+    assert_eq!(augments.len(), 2, "two augment statements expected");
+
+    let top = &augments[0];
+    assert_eq!(top.target, "/sub:top");
+    assert_eq!(
+        top.when.as_ref().map(|w| w.name.as_str()),
+        Some("true()"),
+        "when condition captured"
+    );
+    assert!(top.status.is_some(), "status captured");
+    assert_eq!(top.action.len(), 1, "action captured");
+    assert_eq!(top.action[0].name, "reset");
+    assert_eq!(top.d.leaf.len(), 1, "data-def leaf captured");
+    assert_eq!(top.d.leaf[0].name, "added");
+
+    let sel = &augments[1];
+    assert_eq!(sel.target, "/sub:top/sub:sel");
+    assert_eq!(sel.cases.len(), 1, "case captured");
+    assert_eq!(sel.cases[0].name, "extra");
+}
+
+#[test]
+fn augment_applies_within_same_module() {
+    // The augmenting module's own prefix maps to its own tree, so the
+    // same-module augment in augment-apply.yang resolves and injects
+    // `added` under `top`.
+    let root = load("augment-apply", "tests/yang");
+    let top = find_child(&root, "top").expect("top container");
+    let added = find_child(&top, "added").expect("augmented leaf present");
+    assert!(added.is_leaf(), "augmented node should be a leaf");
 }

--- a/tests/augment.rs
+++ b/tests/augment.rs
@@ -98,3 +98,20 @@ fn augment_applies_within_same_module() {
     let added = find_child(&top, "added").expect("augmented leaf present");
     assert!(added.is_leaf(), "augmented node should be a leaf");
 }
+
+#[test]
+fn uses_augment_injects_into_grouping_subtree() {
+    // tests/yang/uses-augment.yang: container top { uses g { augment
+    // "box" { leaf added; } } } where grouping g defines box/base.
+    // After expansion, box should hold both the grouping's `base` and
+    // the uses-augment's `added`.
+    let root = load("uses-augment", "tests/yang");
+    let top = find_child(&root, "top").expect("top container");
+    let box_ = find_child(&top, "box").expect("box from grouping g");
+    assert!(
+        find_child(&box_, "base").is_some(),
+        "grouping's own leaf should survive"
+    );
+    let added = find_child(&box_, "added").expect("uses-augment leaf present");
+    assert!(added.is_leaf(), "augmented node should be a leaf");
+}

--- a/tests/yang/augment-action.yang
+++ b/tests/yang/augment-action.yang
@@ -1,0 +1,17 @@
+module augment-action {
+  yang-version "1.1";
+  namespace "urn:test:augment-action";
+  prefix "aa";
+
+  container box {
+    leaf base {
+      type string;
+    }
+  }
+
+  // Augment a container with an action (RFC 7950 §7.17 permits action
+  // when the target is a container or list).
+  augment "/aa:box" {
+    action ping;
+  }
+}

--- a/tests/yang/augment-apply.yang
+++ b/tests/yang/augment-apply.yang
@@ -1,0 +1,20 @@
+module augment-apply {
+  yang-version "1.1";
+  namespace "urn:test:augment-apply";
+  prefix "ap";
+
+  container top {
+    leaf base {
+      type string;
+    }
+  }
+
+  // Same-module augment with a `when` guard; to_entry should still
+  // inject `added` under `top`.
+  augment "/ap:top" {
+    when "true()";
+    leaf added {
+      type string;
+    }
+  }
+}

--- a/tests/yang/augment-choice.yang
+++ b/tests/yang/augment-choice.yang
@@ -1,0 +1,26 @@
+module augment-choice {
+  yang-version "1.1";
+  namespace "urn:test:augment-choice";
+  prefix "ac";
+
+  container top {
+    choice sel {
+      case base {
+        leaf b {
+          type string;
+        }
+      }
+    }
+  }
+
+  // Augment a choice with a new case (RFC 7950 §7.17). The case's
+  // children are flattened into the choice's parent and tagged with
+  // the choice/case names.
+  augment "/ac:top/ac:sel" {
+    case extra {
+      leaf c {
+        type string;
+      }
+    }
+  }
+}

--- a/tests/yang/augment-dup.yang
+++ b/tests/yang/augment-dup.yang
@@ -1,0 +1,22 @@
+module augment-dup {
+  yang-version "1.1";
+  namespace "urn:test:augment-dup";
+  prefix "ad";
+
+  container box {
+    leaf base {
+      type string;
+    }
+  }
+
+  // `base` duplicates an existing child and must be rejected (RFC 7950
+  // §7.17); `fresh` is new and must be added.
+  augment "/ad:box" {
+    leaf base {
+      type string;
+    }
+    leaf fresh {
+      type string;
+    }
+  }
+}

--- a/tests/yang/augment-empty-choice.yang
+++ b/tests/yang/augment-empty-choice.yang
@@ -1,0 +1,21 @@
+module augment-empty-choice {
+  yang-version "1.1";
+  namespace "urn:test:augment-empty-choice";
+  prefix "ec";
+
+  container top {
+    // A choice with no cases of its own.
+    choice sel {
+    }
+  }
+
+  // Augmenting an empty choice must still work: the choice is recorded
+  // on `top` even though it contributes no children initially.
+  augment "/ec:top/ec:sel" {
+    case only {
+      leaf v {
+        type string;
+      }
+    }
+  }
+}

--- a/tests/yang/augment-iffeature.yang
+++ b/tests/yang/augment-iffeature.yang
@@ -1,0 +1,25 @@
+module augment-iffeature {
+  yang-version "1.1";
+  namespace "urn:test:augment-iffeature";
+  prefix "iff";
+
+  feature a;
+  feature b;
+  feature c;
+
+  container box {
+    leaf base {
+      type string;
+    }
+  }
+
+  // Compound if-feature expression to exercise and/or/not/parens.
+  // The expression form is unquoted (quoting collapses to a single
+  // identifier per the grammar).
+  augment "/iff:box" {
+    if-feature a and (b or not c);
+    leaf added {
+      type string;
+    }
+  }
+}

--- a/tests/yang/augment-leaf-target.yang
+++ b/tests/yang/augment-leaf-target.yang
@@ -1,0 +1,19 @@
+module augment-leaf-target {
+  yang-version "1.1";
+  namespace "urn:test:augment-leaf-target";
+  prefix "al";
+
+  container box {
+    leaf target {
+      type string;
+    }
+  }
+
+  // Targeting a leaf is invalid (RFC 7950 §7.17); `nope` must not be
+  // added under the leaf.
+  augment "/al:box/al:target" {
+    leaf nope {
+      type string;
+    }
+  }
+}

--- a/tests/yang/augment-substmts.yang
+++ b/tests/yang/augment-substmts.yang
@@ -1,0 +1,36 @@
+module augment-substmts {
+  yang-version "1.1";
+  namespace "urn:test:augment-substmts";
+  prefix "sub";
+
+  container top {
+    choice sel {
+      case base {
+        leaf b {
+          type string;
+        }
+      }
+    }
+  }
+
+  // First augment exercises when / status / a data-def leaf / action
+  // (an action is permitted because the target is a container).
+  augment "/sub:top" {
+    when "true()";
+    status current;
+    leaf added {
+      type string;
+    }
+    action reset;
+  }
+
+  // Second augment exercises an explicit `case` (permitted because the
+  // target is a choice).
+  augment "/sub:top/sub:sel" {
+    case extra {
+      leaf c {
+        type string;
+      }
+    }
+  }
+}

--- a/tests/yang/uses-augment.yang
+++ b/tests/yang/uses-augment.yang
@@ -1,0 +1,25 @@
+module uses-augment {
+  yang-version "1.1";
+  namespace "urn:test:uses-augment";
+  prefix "ua";
+
+  grouping g {
+    container box {
+      leaf base {
+        type string;
+      }
+    }
+  }
+
+  container top {
+    // Instantiate grouping `g` and, via a uses-substatement augment
+    // (descendant form), add `added` into the grouping's `box`.
+    uses g {
+      augment "box" {
+        leaf added {
+          type string;
+        }
+      }
+    }
+  }
+}

--- a/yang.par
+++ b/yang.par
@@ -384,10 +384,16 @@ IfFeatureExpr
 IfFeatureTerm
     : IfFeatureFactor [ <IfFeature>'and' IfFeatureTerm ];
 
+// A feature reference is read directly in the IfFeature scanner so the
+// context stays active across the whole expression. Routing through
+// IdentifierRefArgStr (as before) reset the scanner to INITIAL after the
+// first name, which left a following `and`/`or`/`not` lexed as a plain
+// identifier and broke every compound if-feature expression.
 IfFeatureFactor
     : <IfFeature>'not' IfFeatureFactor
     | <IfFeature>'(' IfFeatureExpr <IfFeature>')'
-    | IdentifierRefArgStr;
+    | Identifier
+    | <IfFeature>'"' Identifier <IfFeature>'"';
 
 PresenceStmt
     : 'presence'^ Ystring Semicolon^;

--- a/yang.par
+++ b/yang.par
@@ -192,6 +192,8 @@ AugmentStmt
       | DescriptionStmt
       | ReferenceStmt
       | DataDefStmt
+      | CaseStmt
+      | ActionStmt
       | NotificationStmt }
       '}'^;
 


### PR DESCRIPTION
## Summary

Closes the gaps between the `augment` statement implementation and RFC 7950 §7.17, delivered in six reviewable stages. Starting point: `augment` parsed only data-defs, silently dropped `when`/`status`/`if-feature`/`case`/`action`/`notification`, ignored `uses`-substatement augments, and applied targets by bare-name with a silent no-op on failure.

## What changed, by stage

1. **Capture substatements + diagnostics** — `AugmentNode` now carries `when`/`status`/`case`/`action`; grammar accepts `case`/`action` in the augment body; target resolution is gated to the augment's own module (fixes cross-module name bleed) and diagnoses unresolved targets instead of silently no-oping.
2. **`uses`-substatement augment** — modelled on `UsesNode` and applied relative to the expanded grouping; all six `uses`-expansion sites centralised through a `uses_entry` helper.
3. **Apply action + choice-case** — augment `action` injected via `action_entry`; augment-into-choice flattens explicit/shorthand cases with the existing choice/case tagging (shared with `choice_entry`).
4. **Validation rules** — duplicate-node rejection (MUST NOT add an existing name), leaf-target rejection, and absolute-vs-descendant target-form checks.
5. **Empty choices** — choices are recorded on their parent (`Entry.choice_defs`) so a choice with no base cases is still augmentable.
6. **if-feature expressions** — parsed into a structured `IfFeatureExprNode` (Feature/Not/And/Or) and captured. Includes a grammar scanner fix: `IfFeatureFactor` reset the scanner to INITIAL after the first feature name, which broke every compound (`and`/`or`/`not`) expression.

## Tests

`tests/augment.rs` grows from 1 to 10 integration tests plus 2 `resolve_target` unit tests, with fixtures under `tests/yang/`. Covers cross-module injection, substatement capture, uses-augment, action/choice/empty-choice application, duplicate/leaf-target rejection, and if-feature precedence.

`cargo test -p libyang` is green; `cargo fmt --check` clean; `cargo clippy` warning count unchanged. Per repo convention, the full bdd/integration suite is left to CI.

## Not in scope (follow-ups)

- `notification` substatement/target — no notification node type exists in the AST/Entry yet.
- Evaluating (vs. capturing) `when`/`if-feature` — needs a data/feature-flag context absent from `to_entry`.
- Quoted **compound** if-feature (`"a and b"`) — still treated as a single identifier; deeper scanner change.
- Augmenting an existing `case` node as a target; per-node namespace on `Entry` (§7.17.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
