### PR TITLE
union: keep numeric/non-string arms of a typedef'd union

### DIFF
--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -637,32 +637,40 @@ where
     for node in type_node.union.iter() {
         if node.kind == YangType::Path {
             if let Some(n) = type_path_resolve(top, store, node) {
-                if n.kind == YangType::String {
-                    let mut m = n.clone();
-                    m.typedef = Some(node.name.clone());
-                    nodes.push(m);
-                }
                 if n.kind == YangType::Union {
+                    // A typedef'd arm whose base is itself a union
+                    // (e.g. `type union { type some-union; … }`).
+                    // type_path_resolve already returned its fully
+                    // resolved arms, so flatten them in directly —
+                    // keeping every arm, not just the String ones.
                     for m in n.union.iter() {
-                        if m.kind == YangType::Path {
-                            if let Some(o) = type_path_resolve(top, store, m) {
-                                if o.kind == YangType::String {
-                                    let mut o = o.clone();
-                                    o.typedef = Some(m.name.clone());
-                                    nodes.push(o);
-                                }
-                            }
-                        }
+                        nodes.push(m.clone());
                     }
+                } else {
+                    // Any other resolved scalar/address/string arm
+                    // (e.g. `inet:as-number` → uint32, `inet:ipv4-
+                    // address`, a patterned string). Previously only
+                    // String arms were kept, so a union like
+                    // `union { inet:as-number; enumeration { … } }`
+                    // silently dropped the numeric arm and rejected
+                    // every numeric value. Preserve the typedef name
+                    // so the matcher can map it via `ytype_from_typedef`
+                    // (e.g. inet:ipv4-address → Ipv4Addr).
+                    let mut m = n.clone();
+                    if m.typedef.is_none() {
+                        m.typedef = Some(node.name.clone());
+                    }
+                    nodes.push(m);
                 }
             }
         } else {
             // Inline union arm with a recognized kind (e.g.
-            // `type string { pattern '...'; }` written directly
-            // inside the union, not via a typedef reference). Keep
-            // it so the matcher can dispatch on it; the previous
-            // drop-on-the-floor behavior was the reason inline
-            // pattern-restricted string arms in unions never engaged.
+            // `type string { pattern '...'; }` or `type uint32;`
+            // written directly inside the union, not via a typedef
+            // reference). Keep it so the matcher can dispatch on it;
+            // the previous drop-on-the-floor behavior was the reason
+            // inline pattern-restricted string arms in unions never
+            // engaged.
             nodes.push(node.clone());
         }
     }

--- a/tests/union_inline_arms.rs
+++ b/tests/union_inline_arms.rs
@@ -57,3 +57,27 @@ fn inline_union_keeps_all_builtin_arms() {
         "string arm must survive; got {kinds:?}"
     );
 }
+
+// Regression: a *typedef'd* union (resolved via type_union_resolve,
+// not type_resolve's inline branch) whose arms include a Path that
+// resolves to a numeric type plus an enumeration. type_union_resolve
+// previously kept only String / Union arms, dropping the numeric arm
+// — so a numeric value was rejected while the enum members were
+// accepted (zebra-rs `interface-neighbor remote-as 65002` refused,
+// `remote-as external` accepted).
+#[test]
+fn typedef_union_keeps_numeric_and_enum_arms() {
+    let root = load("union-sample", "tests/yang");
+    let leaf = find_child(&root, "ref-or-num").expect("ref-or-num leaf");
+    let t = leaf.type_node.as_ref().expect("type_node");
+    assert_eq!(t.kind, YangType::Union);
+    let kinds: Vec<YangType> = t.union.iter().map(|n| n.kind).collect();
+    assert!(
+        kinds.contains(&YangType::Uint32),
+        "numeric (my-as -> uint32) arm of a typedef'd union must survive; got {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&YangType::Enumeration),
+        "enumeration arm must survive; got {kinds:?}"
+    );
+}

--- a/tests/yang/union-sample.yang
+++ b/tests/yang/union-sample.yang
@@ -29,4 +29,31 @@ module union-sample {
       type string;
     }
   }
+
+  // A numeric arm reached via a typedef *reference* (a Path arm),
+  // mirroring `inet:as-number` (which resolves to uint32).
+  typedef my-as {
+    type uint32;
+  }
+
+  // A *typedef'd* union (the leaf references `num-or-keyword`, so
+  // resolution goes through type_union_resolve, not type_resolve's
+  // inline branch) whose arms are a Path-to-numeric and an
+  // enumeration. Regression: type_union_resolve kept only String /
+  // Union arms, so the Path-to-uint32 arm was dropped and a numeric
+  // value (e.g. `remote-as 65002` in zebra-rs's interface-neighbor)
+  // was rejected while the enum members were accepted.
+  typedef num-or-keyword {
+    type union {
+      type my-as;
+      type enumeration {
+        enum external;
+        enum internal;
+      }
+    }
+  }
+
+  leaf ref-or-num {
+    type num-or-keyword;
+  }
 }


### PR DESCRIPTION
## Summary

`type_union_resolve` — the resolution path for a leaf whose type is a **typedef** whose base is a `union` — only kept arms that resolved to `String` or `Union`, **silently dropping a Path arm that resolved to any other built-in** (e.g. `inet:as-number` → `uint32`).

So a union like:

```yang
typedef remote-as-type {
  type union {
    type inet:as-number;                 // <- dropped
    type enumeration { enum external; enum internal; }
  }
}
```

reached the matcher with **only the enumeration arm** — enum members were accepted but every numeric value was rejected. This surfaced in zebra-rs: `set router bgp interface-neighbor i1 remote-as 65002` was refused while `remote-as external` applied.

(`type_resolve`'s *inline* union branch already kept all arms; this makes the typedef'd path consistent with it.)

## Fix

Push every resolved arm: flatten a nested union's already-resolved arms, and preserve the typedef name on a scalar arm so the matcher can still map it via `ytype_from_typedef` (e.g. `inet:ipv4-address` → `Ipv4Addr`).

## Test plan

- `cargo test` — all suites pass, including the new `typedef_union_keeps_numeric_and_enum_arms` regression (a typedef'd union with a Path-to-uint32 arm + an enumeration arm; asserts both `Uint32` and `Enumeration` survive resolution).
- Verified end-to-end against zebra-rs (local `path` dep): with this fix the typed `remote-as` union accepts numeric `65002`, `external`, and `internal`, and still rejects an invalid value.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)