### PR TITLE
Add crates.io metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/zebra-rs/libyang"
 edition = "2024"
 authors = ["Kunihiro Ishiguro <kunihiro@zebra.rs>"]
+readme = "README.md"
+keywords = ["yang", "parser", "networking", "ietf"]
+categories = ["parser-implementations"]
+documentation = "https://docs.rs/libyang"
 exclude = ["/.github/*"]
 
 [dependencies]


### PR DESCRIPTION
## Summary

Adds packaging metadata to `Cargo.toml` to improve the crate's presentation on crates.io and docs.rs:

- `readme = "README.md"`
- `keywords = ["yang", "parser", "networking", "ietf"]`
- `categories = ["parser-implementations"]`
- `documentation = "https://docs.rs/libyang"`

## Test plan

- `cargo verify-project` reports the manifest is valid.

Generated with [Claude Code](https://claude.com/claude-code)