### PR TITLE
2.0: deterministic to_entry() order, drop dead field, clean lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libyang"
-version = "1.1.0"
+version = "2.0.0"
 description = "YANG parser in Rust"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zebra-rs/libyang"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ documentation = "https://docs.rs/libyang"
 exclude = ["/.github/*"]
 
 [dependencies]
-anyhow = "1"
-env_logger = "0.11"
 parol_runtime = "4"
 scnr2 = "0.5"
 thiserror = "2"

--- a/src/nodes/ast.rs
+++ b/src/nodes/ast.rs
@@ -653,8 +653,7 @@ fn import(m: &LinkageStmtsImportStmt) -> ImportNode {
                 node.prefix = Some(prefix);
             }
             ImportStmtListGroup::RevisionDateStmt(m) => {
-                let revision_date =
-                    date_arg_str(&m.revision_date_stmt.date_arg_str);
+                let revision_date = date_arg_str(&m.revision_date_stmt.date_arg_str);
                 node.revision_date = Some(revision_date);
             }
             ImportStmtListGroup::ReferenceStmt(m) => {
@@ -677,8 +676,7 @@ fn include(m: &LinkageStmtsIncludeStmt) -> IncludeNode {
         for m in m.include_stmt_list.iter() {
             match &*m.include_stmt_list_group {
                 IncludeStmtListGroup::RevisionDateStmt(m) => {
-                    let revision_date =
-                        date_arg_str(&m.revision_date_stmt.date_arg_str);
+                    let revision_date = date_arg_str(&m.revision_date_stmt.date_arg_str);
                     node.revision_date = Some(revision_date);
                 }
                 IncludeStmtListGroup::DescriptionStmt(m) => {

--- a/src/nodes/ast.rs
+++ b/src/nodes/ast.rs
@@ -19,7 +19,7 @@ pub fn yang(y: YangGrammar) -> Result<Node, YangError> {
                 Ok(Node::Submodule(Box::new(node)))
             }
         },
-        None => Err(YangError::ParseError),
+        None => Err(YangError::EmptyDocument),
     }
 }
 

--- a/src/nodes/range.rs
+++ b/src/nodes/range.rs
@@ -45,76 +45,28 @@ pub enum RangeNode {
     U64(Vec<Range<u64>>),
 }
 
-impl RangeNode {
-    pub fn to_string(&self) -> String {
-        let mut out = String::from("");
-        match &self {
-            RangeNode::I8(range) => {
-                for r in range.iter() {
-                    if !out.is_empty() {
-                        out.push('|');
-                    }
-                    out.push_str(&format!("{r}"));
-                }
-            }
-            RangeNode::I16(range) => {
-                for r in range.iter() {
-                    if !out.is_empty() {
-                        out.push('|');
-                    }
-                    out.push_str(&format!("{r}"));
-                }
-            }
-            RangeNode::I32(range) => {
-                for r in range.iter() {
-                    if !out.is_empty() {
-                        out.push('|');
-                    }
-                    out.push_str(&format!("{r}"));
-                }
-            }
-            RangeNode::I64(range) => {
-                for r in range.iter() {
-                    if !out.is_empty() {
-                        out.push('|');
-                    }
-                    out.push_str(&format!("{r}"));
-                }
-            }
-            RangeNode::U8(range) => {
-                for r in range.iter() {
-                    if !out.is_empty() {
-                        out.push('|');
-                    }
-                    out.push_str(&format!("{r}"));
-                }
-            }
-            RangeNode::U16(range) => {
-                for r in range.iter() {
-                    if !out.is_empty() {
-                        out.push('|');
-                    }
-                    out.push_str(&format!("{r}"));
-                }
-            }
-            RangeNode::U32(range) => {
-                for r in range.iter() {
-                    if !out.is_empty() {
-                        out.push('|');
-                    }
-                    out.push_str(&format!("{r}"));
-                }
-            }
-            RangeNode::U64(range) => {
-                for r in range.iter() {
-                    if !out.is_empty() {
-                        out.push('|');
-                    }
-                    out.push_str(&format!("{r}"));
-                }
-            }
+impl fmt::Display for RangeNode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Every variant renders the same way and differs only in the
+        // integer width it carries, so the arms just pick the width.
+        fn join<T: fmt::Display>(ranges: &[Range<T>]) -> String {
+            ranges
+                .iter()
+                .map(|r| r.to_string())
+                .collect::<Vec<_>>()
+                .join("|")
         }
-        format!("<{out}>")
+        let out = match self {
+            RangeNode::I8(range) => join(range),
+            RangeNode::I16(range) => join(range),
+            RangeNode::I32(range) => join(range),
+            RangeNode::I64(range) => join(range),
+            RangeNode::U8(range) => join(range),
+            RangeNode::U16(range) => join(range),
+            RangeNode::U32(range) => join(range),
+            RangeNode::U64(range) => join(range),
+        };
+        write!(f, "<{out}>")
     }
 }
 

--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -196,6 +196,14 @@ pub fn to_entry(store: &YangStore, module: &ModuleNode) -> Rc<Entry> {
     // a sibling module that imports the target. Walk all modules
     // once the primary tree is built so augment targets are
     // resolvable.
+    //
+    // Augmented nodes are appended to their target's `dir` as each
+    // augment is applied, so this walk decides the child order of every
+    // augmented node. `store.modules` is a `BTreeMap`, which makes that
+    // order deterministic (by module name) rather than dependent on
+    // hash seeding — see the note on `YangStore`. RFC 7950 does not
+    // prescribe an order across augmenting modules, so any stable one
+    // is conformant.
     for aug in module.augment.iter() {
         apply_augment(module, store, entry.clone(), aug);
     }

--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -136,12 +136,11 @@ impl Entry {
     }
 
     pub fn is_empty_leaf(&self) -> bool {
-        if self.kind == EntryKind::LeafEntry {
-            if let Some(n) = self.type_node.as_ref() {
-                if n.kind == YangType::Empty {
-                    return true;
-                }
-            }
+        if self.kind == EntryKind::LeafEntry
+            && let Some(n) = self.type_node.as_ref()
+            && n.kind == YangType::Empty
+        {
+            return true;
         }
         false
     }
@@ -628,10 +627,10 @@ where
     T: ModuleCommon,
 {
     for import in node.get_import().iter() {
-        if let Some(prefix) = &import.prefix {
-            if name == *prefix {
-                return import.name.clone();
-            }
+        if let Some(prefix) = &import.prefix
+            && name == *prefix
+        {
+            return import.name.clone();
         }
     }
     name
@@ -696,36 +695,36 @@ where
         let module = store.find_module(&prefix);
         if let Some(m) = module {
             for typedef in m.typedef.iter() {
-                if typedef.name == name {
-                    if let Some(node) = &typedef.type_node {
-                        let mut node = node.clone();
-                        node.typedef = Some(type_node.name.clone());
-                        if node.kind == YangType::Union {
-                            return type_union_resolve(top, store, &node);
-                        } else {
-                            return Some(node);
-                        }
+                if typedef.name == name
+                    && let Some(node) = &typedef.type_node
+                {
+                    let mut node = node.clone();
+                    node.typedef = Some(type_node.name.clone());
+                    if node.kind == YangType::Union {
+                        return type_union_resolve(top, store, &node);
+                    } else {
+                        return Some(node);
                     }
                 }
             }
         }
     } else {
         for typedef in top.get_typedef().iter() {
-            if typedef.name == type_node.name {
-                if let Some(node) = &typedef.type_node {
-                    let mut node = node.clone();
-                    node.typedef = Some(type_node.name.clone());
-                    if node.kind == YangType::Union {
-                        // A local typedef whose underlying type is a
-                        // union: resolve its Path arms the same way
-                        // the prefixed branch does, otherwise a leaf
-                        // like `type peer-id-or-all` reaches the
-                        // matcher with every arm still `kind = Path`
-                        // and nothing dispatches.
-                        return type_union_resolve(top, store, &node);
-                    }
-                    return Some(node);
+            if typedef.name == type_node.name
+                && let Some(node) = &typedef.type_node
+            {
+                let mut node = node.clone();
+                node.typedef = Some(type_node.name.clone());
+                if node.kind == YangType::Union {
+                    // A local typedef whose underlying type is a
+                    // union: resolve its Path arms the same way
+                    // the prefixed branch does, otherwise a leaf
+                    // like `type peer-id-or-all` reaches the
+                    // matcher with every arm still `kind = Path`
+                    // and nothing dispatches.
+                    return type_union_resolve(top, store, &node);
                 }
+                return Some(node);
             }
         }
     }
@@ -866,10 +865,10 @@ pub fn choice_entry<T>(top: &T, store: &YangStore, c: &ChoiceNode, ent: Rc<Entry
 where
     T: ModuleCommon,
 {
-    if let Some(config) = &c.config {
-        if !config.config {
-            return;
-        }
+    if let Some(config) = &c.config
+        && !config.config
+    {
+        return;
     }
 
     // Record the choice name on its parent so it stays addressable for
@@ -891,10 +890,10 @@ pub fn container_entry<T>(top: &T, store: &YangStore, c: &ContainerNode, ent: Rc
 where
     T: ModuleCommon,
 {
-    if let Some(config) = &c.config {
-        if !config.config {
-            return;
-        }
+    if let Some(config) = &c.config
+        && !config.config
+    {
+        return;
     }
     let mut e = Entry::new_dir(c.name.clone());
     for u in c.unknown.iter() {
@@ -933,10 +932,10 @@ fn list_entry<T>(top: &T, store: &YangStore, l: &ListNode, ent: Rc<Entry>)
 where
     T: ModuleCommon,
 {
-    if let Some(config) = &l.config {
-        if !config.config {
-            return;
-        }
+    if let Some(config) = &l.config
+        && !config.config
+    {
+        return;
     }
     let mut e = Entry::new_list(l.name.clone(), l.key.keys.clone());
     for u in l.unknown.iter() {
@@ -976,10 +975,10 @@ fn leaf_entry<T>(top: &T, store: &YangStore, leaf: &LeafNode, ent: Rc<Entry>)
 where
     T: ModuleCommon,
 {
-    if let Some(config) = &leaf.config {
-        if !config.config {
-            return;
-        }
+    if let Some(config) = &leaf.config
+        && !config.config
+    {
+        return;
     }
     let mut e = Entry::new_leaf(leaf.name.to_owned());
     e.mandatory = leaf.is_mandatory();
@@ -998,10 +997,10 @@ fn leaf_list_entry<T>(top: &T, store: &YangStore, leaf: &LeafListNode, ent: Rc<E
 where
     T: ModuleCommon,
 {
-    if let Some(config) = &leaf.config {
-        if !config.config {
-            return;
-        }
+    if let Some(config) = &leaf.config
+        && !config.config
+    {
+        return;
     }
     let mut e = Entry::new_leaf(leaf.name.clone());
     for u in leaf.unknown.iter() {

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -55,10 +55,10 @@ impl YangStore {
     }
 
     pub fn identity_resolve(&mut self) {
-        for (_, m) in self.modules.iter_mut() {
+        for m in self.modules.values_mut() {
             identity_resolve(m);
         }
-        for (_, m) in self.submodules.iter_mut() {
+        for m in self.submodules.values_mut() {
             identity_resolve(m);
         }
     }
@@ -117,10 +117,10 @@ impl YangStore {
         for path in &self.paths {
             if path.file_name() == Some(OsStr::new("...")) {
                 let mut dir = path.clone();
-                if dir.pop() {
-                    if let Ok(file_name) = find_in_dir(&dir, module_name, true) {
-                        return Ok(file_name);
-                    }
+                if dir.pop()
+                    && let Ok(file_name) = find_in_dir(&dir, module_name, true)
+                {
+                    return Ok(file_name);
                 }
             }
             if let Ok(file_name) = find_in_dir(path, module_name, false) {
@@ -154,24 +154,25 @@ fn find_in_dir(dir: &PathBuf, module_name: &str, recursive: bool) -> Result<Path
     for entry in dirent.into_iter().flatten() {
         if let Ok(file_type) = entry.file_type() {
             if file_type.is_file() {
-                if let Some(os_str) = entry.path().file_name() {
-                    if let Some(file_str) = os_str.to_str() {
-                        if file_str == file_name {
-                            return Ok(entry.path());
-                        }
-                        // When module_name does not contain '@'.
-                        if module_name.find('@').is_none() {
-                            // Try revision match such as 'ietf-dhcp@2016-08-25.yang'.
-                            if file_str.starts_with(&basename) && file_str.ends_with(".yang") {
-                                revisions.push(entry.path());
-                            }
+                if let Some(os_str) = entry.path().file_name()
+                    && let Some(file_str) = os_str.to_str()
+                {
+                    if file_str == file_name {
+                        return Ok(entry.path());
+                    }
+                    // When module_name does not contain '@'.
+                    if module_name.find('@').is_none() {
+                        // Try revision match such as 'ietf-dhcp@2016-08-25.yang'.
+                        if file_str.starts_with(&basename) && file_str.ends_with(".yang") {
+                            revisions.push(entry.path());
                         }
                     }
                 }
-            } else if file_type.is_dir() && recursive {
-                if let Ok(path) = find_in_dir(&entry.path(), module_name, recursive) {
-                    return Ok(path);
-                }
+            } else if file_type.is_dir()
+                && recursive
+                && let Ok(path) = find_in_dir(&entry.path(), module_name, recursive)
+            {
+                return Ok(path);
             }
         }
     }

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -107,14 +107,21 @@ impl YangStore {
 
     pub fn load_module(&mut self, module_name: &str) -> Result<Node, YangError> {
         let path = self.find_file(module_name)?;
-        let input = fs::read_to_string(&path)?;
+        let input = fs::read_to_string(&path).map_err(|source| YangError::IoError {
+            path: path.clone(),
+            source,
+        })?;
         let mut yang_grammar = YangGrammar::new();
         match parse(&input, &path, &mut yang_grammar) {
             Ok(_) => yang(yang_grammar),
-            Err(err) => {
-                println!("{err:?}");
-                Err(YangError::ParseError)
-            }
+            // Hand the diagnostic back to the caller rather than
+            // printing it: a library has no business writing to stdout,
+            // and the position information is what makes the failure
+            // actionable.
+            Err(source) => Err(YangError::ParseError {
+                path,
+                source: Box::new(source),
+            }),
         }
     }
 
@@ -155,7 +162,10 @@ fn find_in_dir(dir: &PathBuf, module_name: &str, recursive: bool) -> Result<Path
 
     let mut revisions = vec![];
 
-    let dirent = fs::read_dir(dir)?;
+    let dirent = fs::read_dir(dir).map_err(|source| YangError::IoError {
+        path: dir.clone(),
+        source,
+    })?;
     for entry in dirent.into_iter().flatten() {
         if let Ok(file_type) = entry.file_type() {
             if file_type.is_file() {
@@ -182,7 +192,9 @@ fn find_in_dir(dir: &PathBuf, module_name: &str, recursive: bool) -> Result<Path
         }
     }
     if revisions.is_empty() {
-        return Err(YangError::FileNotFound);
+        return Err(YangError::FileNotFound {
+            name: module_name.to_string(),
+        });
     }
 
     // When the specified file is not found by exact match, directories are

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -1,7 +1,7 @@
 use crate::yang_grammar::YangGrammar;
 use crate::yang_parser::parse;
 use crate::*;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs::{self};
 use std::path::PathBuf;
@@ -9,9 +9,17 @@ use std::path::PathBuf;
 #[derive(Debug, Default)]
 pub struct YangStore {
     paths: Vec<PathBuf>,
-    pub modules: HashMap<String, ModuleNode>,
-    pub submodules: HashMap<String, SubmoduleNode>,
-    pub import: HashMap<String, ModuleNode>,
+    // These are `BTreeMap`, not `HashMap`, so iterating them is
+    // deterministic. `to_entry` walks `modules` to apply each loaded
+    // module's augments, and augmented nodes are appended to their
+    // target's `dir` in application order — so with a randomly ordered
+    // map the shape of the resulting tree changed on every run of the
+    // same program over the same files. Key order (module name) is
+    // arbitrary but stable, which is what consumers need to produce
+    // reproducible output.
+    pub modules: BTreeMap<String, ModuleNode>,
+    pub submodules: BTreeMap<String, SubmoduleNode>,
+    pub import: BTreeMap<String, ModuleNode>,
 }
 
 impl YangStore {

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -9,6 +9,11 @@ use std::path::PathBuf;
 #[derive(Debug, Default)]
 pub struct YangStore {
     paths: Vec<PathBuf>,
+    // Crate-private: reach these through `find_module` /
+    // `find_submodule`. Keeping the storage an implementation detail
+    // means its type can change without breaking callers — which is
+    // exactly what the switch below could not do while it was public.
+    //
     // These are `BTreeMap`, not `HashMap`, so iterating them is
     // deterministic. `to_entry` walks `modules` to apply each loaded
     // module's augments, and augmented nodes are appended to their
@@ -17,8 +22,8 @@ pub struct YangStore {
     // same program over the same files. Key order (module name) is
     // arbitrary but stable, which is what consumers need to produce
     // reproducible output.
-    pub modules: BTreeMap<String, ModuleNode>,
-    pub submodules: BTreeMap<String, SubmoduleNode>,
+    pub(crate) modules: BTreeMap<String, ModuleNode>,
+    pub(crate) submodules: BTreeMap<String, SubmoduleNode>,
 }
 
 impl YangStore {

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -19,7 +19,6 @@ pub struct YangStore {
     // reproducible output.
     pub modules: BTreeMap<String, ModuleNode>,
     pub submodules: BTreeMap<String, SubmoduleNode>,
-    pub import: BTreeMap<String, ModuleNode>,
 }
 
 impl YangStore {

--- a/src/store/yerror.rs
+++ b/src/store/yerror.rs
@@ -1,13 +1,40 @@
-//use thiserror;
+use parol_runtime::ParolError;
+use std::path::PathBuf;
 
+/// Errors returned while locating, reading and parsing YANG modules.
+///
+/// Every variant names the file it applies to, and `ParseError` carries
+/// the underlying parol diagnostic (which reports the position of the
+/// offending token), so a failure can be reported by the caller without
+/// the library writing anything to stdout itself. The `Display` text
+/// includes the source message, so printing the error alone is enough;
+/// `#[source]` is also set for callers that walk the chain.
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum YangError {
-    #[error(transparent)]
-    IoError(#[from] std::io::Error),
+    /// Reading a YANG file, or scanning a search directory, failed.
+    #[error("{}: {source}", path.display())]
+    IoError {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 
-    #[error("YANG file not found")]
-    FileNotFound,
+    /// No file matching the module name was found on the search path.
+    #[error("YANG module `{name}` not found in the search path")]
+    FileNotFound { name: String },
 
-    #[error("YANG file parse error")]
-    ParseError,
+    /// The file was read but did not parse as YANG.
+    #[error("{}: {source}", path.display())]
+    ParseError {
+        path: PathBuf,
+        // Boxed because ParolError is comparatively large, and this
+        // error rides in every Result the loader returns.
+        #[source]
+        source: Box<ParolError>,
+    },
+
+    /// The file parsed, but contained neither a module nor a submodule.
+    #[error("YANG document contains neither a module nor a submodule")]
+    EmptyDocument,
 }

--- a/tests/augment_order.rs
+++ b/tests/augment_order.rs
@@ -1,0 +1,87 @@
+// Regression test: `to_entry` must produce the same child order on
+// every run.
+//
+// Augmented nodes are appended to their target's `dir` as each
+// augment is applied, so the child order is decided by the order
+// `to_entry` walks the loaded modules. `YangStore::modules` is a
+// `BTreeMap` to make that walk deterministic. It was a `HashMap`, and
+// because Rust seeds each `HashMap` instance separately the order
+// differed not just between processes but between two stores in the
+// same process — which is what these tests exercise, by loading the
+// same files through several fresh stores and comparing.
+//
+// tests/yang/augment-order-target.yang defines `container root` and
+// bootstrap-imports six sibling modules (augment-order-{a..f}), each
+// augmenting `/base:root` with one leaf. Six siblings give 720
+// possible orders, so repeated loads agreeing by chance is not a
+// plausible explanation for a pass.
+
+use libyang::{Entry, YangStore, to_entry};
+use std::rc::Rc;
+
+const YANG_DIR: &str = "tests/yang";
+const TARGET: &str = "augment-order-target";
+
+/// Build the tree from a *fresh* store, so each call gets its own
+/// `HashMap` instance (and thus its own iteration order).
+fn load_root() -> Rc<Entry> {
+    let mut store = YangStore::new();
+    store.add_path(YANG_DIR);
+    store.read_with_resolve(TARGET).expect("parse / resolve");
+    store.identity_resolve();
+    let module = store.find_module(TARGET).expect("module found");
+    let entry = to_entry(&store, module);
+    entry
+        .dir
+        .borrow()
+        .iter()
+        .find(|e| e.name == "root")
+        .cloned()
+        .expect("container root")
+}
+
+fn child_names(ent: &Rc<Entry>) -> Vec<String> {
+    ent.dir.borrow().iter().map(|e| e.name.clone()).collect()
+}
+
+#[test]
+fn augment_child_order_is_stable_across_loads() {
+    let first = child_names(&load_root());
+
+    // All six augments landed, so the order really is observable.
+    for m in ["a", "b", "c", "d", "e", "f"] {
+        let leaf = format!("leaf-{m}");
+        assert!(
+            first.contains(&leaf),
+            "augment from augment-order-{m} missing; got {first:?}"
+        );
+    }
+
+    for i in 1..8 {
+        let next = child_names(&load_root());
+        assert_eq!(
+            first, next,
+            "augmented child order changed between load 0 and load {i}: \
+             to_entry must not depend on the hash seeding of the store's \
+             module map"
+        );
+    }
+}
+
+#[test]
+fn augment_child_order_is_sorted_by_module_name() {
+    // The chosen deterministic order is the augmenting modules' names,
+    // sorted. Pin it so the guarantee is a documented contract rather
+    // than an accident of the implementation.
+    let names = child_names(&load_root());
+    let augmented: Vec<&String> = names.iter().filter(|n| n.starts_with("leaf-")).collect();
+    let want = ["leaf-a", "leaf-b", "leaf-c", "leaf-d", "leaf-e", "leaf-f"];
+    assert_eq!(
+        augmented.len(),
+        want.len(),
+        "expected one leaf per augmenting module; got {augmented:?}"
+    );
+    for (got, want) in augmented.iter().zip(want.iter()) {
+        assert_eq!(got.as_str(), *want, "augment order: {augmented:?}");
+    }
+}

--- a/tests/choice_flatten.rs
+++ b/tests/choice_flatten.rs
@@ -21,7 +21,7 @@ fn load(name: &str, yang_dir: &str) -> Rc<Entry> {
     to_entry(&store, module)
 }
 
-fn find_child<'a>(ent: &'a Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
+fn find_child(ent: &Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
     ent.dir.borrow().iter().find(|e| e.name == name).cloned()
 }
 

--- a/tests/error_context.rs
+++ b/tests/error_context.rs
@@ -1,0 +1,87 @@
+// `YangError` must identify what failed and where.
+//
+// Loading used to report "YANG file parse error" with no indication of
+// which file, having printed the real parol diagnostic to stdout and
+// then dropped it. These tests pin the replacement: the error names the
+// file or module, and the parse diagnostic survives on the error chain
+// for callers that want the position of the offending token.
+
+use libyang::{YangError, YangStore};
+use std::error::Error;
+
+const YANG_DIR: &str = "tests/yang";
+
+fn load_err(name: &str) -> YangError {
+    let mut store = YangStore::new();
+    store.add_path(YANG_DIR);
+    store
+        .read_with_resolve(name)
+        .expect_err("module is expected to fail loading")
+}
+
+#[test]
+fn missing_module_names_the_module() {
+    let err = load_err("no-such-module");
+    match &err {
+        YangError::FileNotFound { name } => assert_eq!(name, "no-such-module"),
+        other => panic!("expected FileNotFound, got {other:?}"),
+    }
+    // The name has to reach the rendered message, not just the struct —
+    // most callers only ever print the error.
+    assert!(
+        err.to_string().contains("no-such-module"),
+        "message should name the module: {err}"
+    );
+}
+
+#[test]
+fn parse_failure_names_the_file() {
+    // tests/yang/malformed.yang has a `type` statement with no argument.
+    let err = load_err("malformed");
+    match &err {
+        YangError::ParseError { path, .. } => {
+            assert!(
+                path.ends_with("malformed.yang"),
+                "expected the offending path, got {path:?}"
+            );
+        }
+        other => panic!("expected ParseError, got {other:?}"),
+    }
+    assert!(
+        err.to_string().contains("malformed.yang"),
+        "message should name the file: {err}"
+    );
+}
+
+#[test]
+fn parse_failure_keeps_the_parol_diagnostic() {
+    let err = load_err("malformed");
+
+    // The diagnostic is reachable as the error's source ...
+    let source = err.source().expect("parse error should have a source");
+
+    // ... and still carries the position of the offending token, which
+    // is the part that makes the failure actionable. The `type`
+    // statement is on line 7, so the parser trips at the following
+    // line; assert on the file:line shape rather than an exact number.
+    let detail = format!("{source:?}");
+    assert!(
+        detail.contains("start_line: 8"),
+        "expected token position in the preserved diagnostic: {detail}"
+    );
+    assert!(
+        detail.contains("malformed.yang"),
+        "expected the file name in the preserved diagnostic: {detail}"
+    );
+}
+
+#[test]
+fn a_healthy_module_still_loads() {
+    // Guard against the error plumbing accidentally rejecting good input.
+    let mut store = YangStore::new();
+    store.add_path(YANG_DIR);
+    store
+        .read_with_resolve("augment-order-target")
+        .expect("valid module loads");
+    assert!(store.find_module("augment-order-target").is_some());
+}

--- a/tests/leafref_path.rs
+++ b/tests/leafref_path.rs
@@ -15,7 +15,7 @@ fn load(name: &str, yang_dir: &str) -> Rc<Entry> {
     to_entry(&store, module)
 }
 
-fn find_child<'a>(ent: &'a Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
+fn find_child(ent: &Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
     ent.dir.borrow().iter().find(|e| e.name == name).cloned()
 }
 

--- a/tests/range_display.rs
+++ b/tests/range_display.rs
@@ -1,0 +1,59 @@
+// `RangeNode`'s rendering used to be an inherent `to_string`; it is now
+// a `Display` impl (which still provides `.to_string()`, via the
+// standard blanket impl). These cases pin the output format so the
+// conversion cannot silently change what callers see — the first three
+// were checked to pass against the previous implementation as well.
+
+use libyang::{Range, RangeNode, RangeVal};
+
+fn bounded<T>(start: T, end: T) -> Range<T> {
+    Range {
+        start: RangeVal::Val(start),
+        end: Some(RangeVal::Val(end)),
+    }
+}
+
+fn single<T>(v: T) -> Range<T> {
+    Range {
+        start: RangeVal::Val(v),
+        end: None,
+    }
+}
+
+#[test]
+fn renders_single_and_multiple_ranges() {
+    assert_eq!(RangeNode::U8(vec![bounded(0u8, 9u8)]).to_string(), "<0..9>");
+    assert_eq!(RangeNode::I32(vec![single(42i32)]).to_string(), "<42>");
+
+    // Several ranges are joined with '|', in order.
+    let multi = RangeNode::I16(vec![
+        bounded(-5i16, -1i16),
+        single(0i16),
+        bounded(1i16, 5i16),
+    ]);
+    assert_eq!(multi.to_string(), "<-5..-1|0|1..5>");
+}
+
+#[test]
+fn renders_min_max_keywords() {
+    let node = RangeNode::I64(vec![Range {
+        start: RangeVal::Min,
+        end: Some(RangeVal::Max),
+    }]);
+    assert_eq!(node.to_string(), "<min..max>");
+}
+
+#[test]
+fn renders_empty_range_list() {
+    // No ranges: the delimiters are still emitted, matching the
+    // previous inherent implementation.
+    assert_eq!(RangeNode::U64(vec![]).to_string(), "<>");
+}
+
+#[test]
+fn usable_through_the_display_trait() {
+    // The point of the conversion: RangeNode now works anywhere a
+    // Display value is accepted, not just via an inherent method.
+    let node = RangeNode::U32(vec![bounded(1u32, 2u32)]);
+    assert_eq!(format!("{node}"), "<1..2>");
+}

--- a/tests/union_inline_arms.rs
+++ b/tests/union_inline_arms.rs
@@ -20,7 +20,7 @@ fn load(name: &str, yang_dir: &str) -> Rc<Entry> {
     to_entry(&store, module)
 }
 
-fn find_child<'a>(ent: &'a Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
+fn find_child(ent: &Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
     ent.dir.borrow().iter().find(|e| e.name == name).cloned()
 }
 

--- a/tests/yang/augment-order-a.yang
+++ b/tests/yang/augment-order-a.yang
@@ -1,0 +1,16 @@
+module augment-order-a {
+  yang-version "1.1";
+  namespace "urn:test:augment-order-a";
+  prefix "orda";
+
+  import augment-order-target {
+    prefix base;
+  }
+
+  augment "/base:root" {
+    leaf leaf-a {
+      type string;
+      description "One of several sibling augments of the same target.";
+    }
+  }
+}

--- a/tests/yang/augment-order-b.yang
+++ b/tests/yang/augment-order-b.yang
@@ -1,0 +1,16 @@
+module augment-order-b {
+  yang-version "1.1";
+  namespace "urn:test:augment-order-b";
+  prefix "ordb";
+
+  import augment-order-target {
+    prefix base;
+  }
+
+  augment "/base:root" {
+    leaf leaf-b {
+      type string;
+      description "One of several sibling augments of the same target.";
+    }
+  }
+}

--- a/tests/yang/augment-order-c.yang
+++ b/tests/yang/augment-order-c.yang
@@ -1,0 +1,16 @@
+module augment-order-c {
+  yang-version "1.1";
+  namespace "urn:test:augment-order-c";
+  prefix "ordc";
+
+  import augment-order-target {
+    prefix base;
+  }
+
+  augment "/base:root" {
+    leaf leaf-c {
+      type string;
+      description "One of several sibling augments of the same target.";
+    }
+  }
+}

--- a/tests/yang/augment-order-d.yang
+++ b/tests/yang/augment-order-d.yang
@@ -1,0 +1,16 @@
+module augment-order-d {
+  yang-version "1.1";
+  namespace "urn:test:augment-order-d";
+  prefix "ordd";
+
+  import augment-order-target {
+    prefix base;
+  }
+
+  augment "/base:root" {
+    leaf leaf-d {
+      type string;
+      description "One of several sibling augments of the same target.";
+    }
+  }
+}

--- a/tests/yang/augment-order-e.yang
+++ b/tests/yang/augment-order-e.yang
@@ -1,0 +1,16 @@
+module augment-order-e {
+  yang-version "1.1";
+  namespace "urn:test:augment-order-e";
+  prefix "orde";
+
+  import augment-order-target {
+    prefix base;
+  }
+
+  augment "/base:root" {
+    leaf leaf-e {
+      type string;
+      description "One of several sibling augments of the same target.";
+    }
+  }
+}

--- a/tests/yang/augment-order-f.yang
+++ b/tests/yang/augment-order-f.yang
@@ -1,0 +1,16 @@
+module augment-order-f {
+  yang-version "1.1";
+  namespace "urn:test:augment-order-f";
+  prefix "ordf";
+
+  import augment-order-target {
+    prefix base;
+  }
+
+  augment "/base:root" {
+    leaf leaf-f {
+      type string;
+      description "One of several sibling augments of the same target.";
+    }
+  }
+}

--- a/tests/yang/augment-order-target.yang
+++ b/tests/yang/augment-order-target.yang
@@ -1,0 +1,35 @@
+module augment-order-target {
+  yang-version "1";
+  namespace "urn:test:augment-order-target";
+  prefix "base";
+
+  // Bootstrap imports: these pull the augmenting modules into the
+  // store's closure so their augments are applied to `root`. Six
+  // siblings all augment the same target, so the resulting child
+  // order is decided entirely by the order `to_entry` walks the
+  // loaded modules.
+  import augment-order-a {
+    prefix orda;
+  }
+  import augment-order-b {
+    prefix ordb;
+  }
+  import augment-order-c {
+    prefix ordc;
+  }
+  import augment-order-d {
+    prefix ordd;
+  }
+  import augment-order-e {
+    prefix orde;
+  }
+  import augment-order-f {
+    prefix ordf;
+  }
+
+  container root {
+    leaf anchor {
+      type string;
+    }
+  }
+}

--- a/tests/yang/malformed.yang
+++ b/tests/yang/malformed.yang
@@ -1,0 +1,10 @@
+module malformed {
+  namespace "urn:test:malformed";
+  prefix "mal";
+
+  container root {
+    leaf broken {
+      type
+    }
+  }
+}


### PR DESCRIPTION
Five commits, reviewable independently. The first is the reason for the
release; the rest is breaking/cleanup work that belongs in the same
major version.

## 1. Make `to_entry()` child order deterministic

`to_entry()` applies each loaded module's augments after building the
primary tree, walking the store's module map to find them. That map was
a `HashMap`, and Rust seeds every `HashMap` instance differently, so the
walk order was effectively random. Augmented nodes are appended to their
target's `dir` as they are applied, so **the resulting child order
differed on every run** over the same YANG files — and even between two
`YangStore`s in the same process.

Measured against zebra-rs's schema: dumping one 3050-node tree five
times produced **five distinct orderings** — identical node sets, order
only. That makes any output derived from tree order irreproducible,
which defeats golden-file tests and inflates diffs of generated
documentation.

Fix: make `YangStore`'s name-keyed maps `BTreeMap`s. RFC 7950 does not
prescribe an order across augmenting modules, so any deterministic one
is conformant. Fixing it at the data structure rather than at the one
call site means a later iteration cannot silently reintroduce it.

`tests/augment_order.rs` pins both properties: repeated loads agree, and
the order is the augmenting modules' names sorted. Six sibling modules
augment one target (720 possible orders), so passing by coincidence is
not plausible. Each load uses a fresh store, so the test catches the bug
**within a single process**. Verified red on the previous code:

```
left:  ["anchor", "leaf-d", "leaf-f", "leaf-e", "leaf-b", "leaf-c", "leaf-a"]
right: ["anchor", "leaf-a", "leaf-f", "leaf-e", "leaf-b", "leaf-c", "leaf-d"]
```

## 2. Remove the unused `YangStore::import` field

Never read or written. The only `.import` accesses are on `ModuleNode` /
`SubmoduleNode`, whose `import` is the parsed `Vec<ImportNode>` — a
different field that happens to share the name. Import resolution goes
through `modules`.

## 3. Fix clippy lints and rustfmt drift

`clippy --all-targets -- -D warnings` reported 18 lints on `main`; it is
now clean. Mostly mechanical (`collapsible_if` ×13, `iter_kv_map` ×2,
`needless_lifetimes` ×3) via `clippy --fix`.

One needed a real change. `inherent_to_string`: `RangeNode` had an
inherent `to_string` shadowing the conventional trait-based one. It now
implements `Display`, so `.to_string()` still works via the blanket impl
and the type is usable anywhere a Display value is accepted. The eight
match arms were identical apart from integer width, so they share a
generic helper — 90 lines to 24. `RangeVal` and `Range` in the same file
already implement `Display`, so this follows the file's own idiom.

`tests/range_display.rs` pins the rendered format; its single/multiple,
min/max and empty-list cases were run against the previous inherent
implementation and pass unchanged there, so the rewrite is
output-equivalent.

## 4. Make the module maps crate-private

Nothing outside the crate reads `modules` or `submodules` — tests, the
README and the downstream consumer all use `find_module` /
`find_submodule`. Keeping them public makes the storage type part of the
API, which is exactly why commit 1 was breaking. `pub(crate)` now means
the next such change is not.

## 5. Report load errors instead of printing them

`load_module` printed parol's diagnostic to stdout with `println!` and
then returned a bare `ParseError`. A library writing to stdout corrupts
the output of any CLI built on it, and the actionable part — which file,
which line, which token — was discarded after printing, so callers could
only report "YANG file parse error".

Every variant now carries its context, and the parol diagnostic is
handed back on the error chain:

- `ParseError { path, source }` keeps the full `ParolError` (token
  position, expected-token set, source text).
- `FileNotFound { name }` names the unresolved module.
- `IoError { path, source }` names the file or directory.
- `EmptyDocument` is new, for input that parses but declares neither a
  module nor a submodule — previously conflated with `ParseError`.

`Display` embeds the source message, so printing the error alone
suffices: a broken file now yields `tests/yang/malformed.yang: Syntax
error(s)` instead of `YANG file parse error`. `YangError` is also
`#[non_exhaustive]`, so later variants are additive.

`tests/error_context.rs` covers it: both failures name the module/file,
the parol diagnostic survives with the offending token's line, and a
healthy module still loads.

## 6. Drop the unused `anyhow` and `env_logger` dependencies

Neither is referenced anywhere in the crate — not in `src/`, `tests/` or
`build.rs`, and not in the parol-generated parser either. `env_logger`
in particular is a binary-side crate: initialising a logger is the
application's job, not a library's.

`env_logger` leaves the runtime dependency graph entirely (parol still
pulls it in, but only as a build-dependency for parser generation, so it
no longer compiles into anything downstream links). `anyhow` stays in
the graph transitively via `parol_runtime`, which genuinely uses it, but
is no longer a declared direct dependency. Direct runtime dependencies
go from five to three.

Non-breaking on its own.

## Breaking changes → 2.0.0

Public field types changed (`HashMap` → `BTreeMap`) and are now
`pub(crate)`; `YangStore::import` is removed; `RangeNode::to_string`
moved to `Display`; every `YangError` variant changed shape, the enum is
`#[non_exhaustive]`, and `From<std::io::Error>` is gone.

Verified against the main consumer rather than assumed: zebra-rs
**compiles unchanged** against this branch (`cargo check --all-targets`,
only the `Cargo.toml` pin swapped to a path dependency) and its full
suite passes — 1662 tests, including a schema audit that byte-compares a
committed 307-line schema dump, so the upgrade causes no churn there.
zebra-rs will need `libyang = "2"` and no source change.

Callers that construct a store and call `find_module` /
`read_with_resolve` / `identity_resolve` / `to_entry` are unaffected
apart from the pin. Callers that matched on `YangError` need to update.

## Verification

- Full suite green (12 suites). `cargo fmt --check` clean.
  `clippy --all-targets -- -D warnings` clean (was 18).
- Five-run dump of zebra-rs's 3050-node tree now yields **one** ordering,
  with the node set identical to stock libyang — so the refactors change
  ordering only, not what the parser produces.

Generated with [Claude Code](https://claude.com/claude-code)