### PR TITLE
Collect augment diagnostics instead of printing them

### DIFF
--- a/src/store/diagnostic.rs
+++ b/src/store/diagnostic.rs
@@ -1,0 +1,115 @@
+use std::fmt;
+
+/// Which flavour of `augment` a diagnostic came from. The two differ in
+/// how their target is written (RFC 7950 §7.17), so the distinction
+/// matters when reporting a bad target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AugmentKind {
+    /// A top-level `augment` statement.
+    Augment,
+    /// An `augment` substatement of a `uses`.
+    UsesAugment,
+}
+
+impl fmt::Display for AugmentKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AugmentKind::Augment => write!(f, "augment"),
+            AugmentKind::UsesAugment => write!(f, "uses augment"),
+        }
+    }
+}
+
+/// A problem found while building an [`Entry`](crate::Entry) tree.
+///
+/// These are warnings rather than errors: `to_entry` still returns a
+/// tree, with the offending augment skipped or its duplicate child
+/// removed. They are collected on the [`YangStore`](crate::YangStore)
+/// (see [`YangStore::diagnostics`](crate::YangStore::diagnostics)) so
+/// the caller decides whether to log them, fail a build, or ignore
+/// them — previously they were written straight to stderr, which left
+/// a library deciding how an application reports its problems.
+///
+/// Each variant names the module whose augment is at fault, so a
+/// diagnostic is actionable without re-deriving where it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Diagnostic {
+    /// A top-level `augment` target must be an absolute
+    /// schema-node-identifier (leading `/`).
+    AugmentTargetNotAbsolute { module: String, target: String },
+
+    /// A `uses`-substatement `augment` target must be a descendant
+    /// schema-node-identifier (no leading `/`).
+    AugmentTargetNotDescendant { module: String, target: String },
+
+    /// The augment target did not resolve to any node in the tree.
+    /// `missing` is the first path segment that failed to match.
+    AugmentTargetNotFound {
+        kind: AugmentKind,
+        module: String,
+        target: String,
+        missing: String,
+    },
+
+    /// The target resolved to a leaf or leaf-list. Data nodes and
+    /// actions may only be added to a container, list, choice, case,
+    /// input, output or notification.
+    AugmentIntoLeaf {
+        module: String,
+        target: String,
+        leaf: String,
+    },
+
+    /// The augment introduced a child whose name already existed in the
+    /// target, so it was dropped. An augment must not shadow a node
+    /// already present.
+    AugmentDuplicateNode {
+        module: String,
+        target: String,
+        name: String,
+    },
+}
+
+impl fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Diagnostic::AugmentTargetNotAbsolute { module, target } => write!(
+                f,
+                "{module}: augment target \"{target}\" must use the absolute form (leading '/')"
+            ),
+            Diagnostic::AugmentTargetNotDescendant { module, target } => write!(
+                f,
+                "{module}: uses augment target \"{target}\" must use the descendant form \
+                 (no leading '/')"
+            ),
+            Diagnostic::AugmentTargetNotFound {
+                kind,
+                module,
+                target,
+                missing,
+            } => write!(
+                f,
+                "{module}: {kind} target \"{target}\" not found \
+                 (no node matching \"{missing}\")"
+            ),
+            Diagnostic::AugmentIntoLeaf {
+                module,
+                target,
+                leaf,
+            } => write!(
+                f,
+                "{module}: augment cannot add nodes to leaf target \"{leaf}\" ({target})"
+            ),
+            Diagnostic::AugmentDuplicateNode {
+                module,
+                target,
+                name,
+            } => write!(
+                f,
+                "{module}: augment node \"{name}\" already exists in target \"{target}\"; \
+                 not added"
+            ),
+        }
+    }
+}

--- a/src/store/entry.rs
+++ b/src/store/entry.rs
@@ -287,12 +287,12 @@ where
     // RFC 7950 §7.17: a top-level augment's target is an
     // absolute-schema-nodeid (leading '/').
     if !aug.target.starts_with('/') {
-        eprintln!(
-            "augment: top-level target \"{}\" must use the absolute form (leading '/')",
-            aug.target
-        );
+        store.diag(Diagnostic::AugmentTargetNotAbsolute {
+            module: top.get_name().to_string(),
+            target: aug.target.clone(),
+        });
     }
-    resolve_and_inject(top, store, root, aug, "augment");
+    resolve_and_inject(top, store, root, aug, AugmentKind::Augment);
 }
 
 /// Expand a `uses` into `ent`: instantiate the referenced grouping,
@@ -322,12 +322,12 @@ where
     // RFC 7950 §7.17: a uses-substatement augment's target is a
     // descendant-schema-nodeid (no leading '/').
     if aug.target.starts_with('/') {
-        eprintln!(
-            "uses augment: target \"{}\" must use the descendant form (no leading '/')",
-            aug.target
-        );
+        store.diag(Diagnostic::AugmentTargetNotDescendant {
+            module: top.get_name().to_string(),
+            target: aug.target.clone(),
+        });
     }
-    resolve_and_inject(top, store, ent, aug, "uses augment");
+    resolve_and_inject(top, store, ent, aug, AugmentKind::UsesAugment);
 }
 
 /// Resolve `aug.target` from `root` and inject the augment body.
@@ -335,20 +335,25 @@ where
 /// diagnostic). If the path resolves to a data node, inject there; if
 /// the final segment instead names a choice (choices are flattened and
 /// not addressable as entries), add the augment's cases to that choice.
-fn resolve_and_inject<T>(top: &T, store: &YangStore, root: Rc<Entry>, aug: &AugmentNode, kind: &str)
-where
+fn resolve_and_inject<T>(
+    top: &T,
+    store: &YangStore,
+    root: Rc<Entry>,
+    aug: &AugmentNode,
+    kind: AugmentKind,
+) where
     T: ModuleCommon,
 {
     match resolve_target(root.clone(), &aug.target) {
         Ok(current) => inject_augment_body(top, store, current, aug),
         Err(seg) => {
             if !augment_into_choice(top, store, root, aug) {
-                eprintln!(
-                    "{kind}: in module {}, target \"{}\" not found (no node matching \"{}\")",
-                    top.get_name(),
-                    aug.target,
-                    seg
-                );
+                store.diag(Diagnostic::AugmentTargetNotFound {
+                    kind,
+                    module: top.get_name().to_string(),
+                    target: aug.target.clone(),
+                    missing: seg,
+                });
             }
         }
     }
@@ -368,10 +373,11 @@ where
     // leaf or leaf-list. Resolution lands on a leaf only when the
     // augment is malformed.
     if current.is_leaf_entry() {
-        eprintln!(
-            "augment: cannot add nodes to leaf target \"{}\" ({})",
-            current.name, aug.target
-        );
+        store.diag(Diagnostic::AugmentIntoLeaf {
+            module: top.get_name().to_string(),
+            target: aug.target.clone(),
+            leaf: current.name.clone(),
+        });
         return;
     }
 
@@ -395,10 +401,11 @@ where
     let mut i = before_len;
     while i < dir.len() {
         if existing.contains(&dir[i].name) {
-            eprintln!(
-                "augment: node \"{}\" already exists in target \"{}\"; not added",
-                dir[i].name, current.name
-            );
+            store.diag(Diagnostic::AugmentDuplicateNode {
+                module: top.get_name().to_string(),
+                target: aug.target.clone(),
+                name: dir[i].name.clone(),
+            });
             dir.remove(i);
         } else {
             i += 1;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,3 +1,6 @@
+pub mod diagnostic;
+pub use diagnostic::*;
+
 pub mod reader;
 pub use reader::*;
 

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -1,6 +1,7 @@
 use crate::yang_grammar::YangGrammar;
 use crate::yang_parser::parse;
 use crate::*;
+use std::cell::{Ref, RefCell};
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs::{self};
@@ -24,6 +25,11 @@ pub struct YangStore {
     // reproducible output.
     pub(crate) modules: BTreeMap<String, ModuleNode>,
     pub(crate) submodules: BTreeMap<String, SubmoduleNode>,
+    // Problems found while building entry trees. `to_entry` takes the
+    // store by shared reference and the whole augment path already has
+    // it in scope, so a `RefCell` collects diagnostics here without
+    // threading a channel through 20 functions.
+    diagnostics: RefCell<Vec<Diagnostic>>,
 }
 
 impl YangStore {
@@ -148,6 +154,31 @@ impl YangStore {
 
     pub fn find_submodule(&self, name: &str) -> Option<&SubmoduleNode> {
         self.submodules.get(name)
+    }
+
+    /// Problems found while building entry trees with
+    /// [`to_entry`](crate::to_entry), in the order they were found.
+    ///
+    /// These are warnings: a tree is still produced, with the offending
+    /// augment skipped. They accumulate across calls, so a caller
+    /// checking one module at a time should use
+    /// [`take_diagnostics`](Self::take_diagnostics) instead.
+    ///
+    /// The returned guard borrows the store; hold it only as long as
+    /// needed, since building another tree while it is alive will
+    /// panic.
+    pub fn diagnostics(&self) -> Ref<'_, Vec<Diagnostic>> {
+        self.diagnostics.borrow()
+    }
+
+    /// Take the collected diagnostics, leaving the store empty.
+    pub fn take_diagnostics(&self) -> Vec<Diagnostic> {
+        std::mem::take(&mut self.diagnostics.borrow_mut())
+    }
+
+    /// Record a problem found while building an entry tree.
+    pub(crate) fn diag(&self, diagnostic: Diagnostic) {
+        self.diagnostics.borrow_mut().push(diagnostic);
     }
 }
 

--- a/tests/augment_diagnostics.rs
+++ b/tests/augment_diagnostics.rs
@@ -1,0 +1,150 @@
+// Malformed augments are reported, not printed.
+//
+// `to_entry` used to write these five problems to stderr and carry on,
+// which left a library deciding how an application reports its
+// problems, and gave callers no way to react to them. They are now
+// collected on the store, so a build can log them, fail on them, or
+// ignore them.
+//
+// The tree behaviour is unchanged and still covered by tests/augment.rs;
+// these tests cover the reporting.
+
+use libyang::{AugmentKind, Diagnostic, Entry, YangStore, to_entry};
+use std::rc::Rc;
+
+const YANG_DIR: &str = "tests/yang";
+
+/// Build `name`'s tree and return it with whatever was reported.
+fn load_with_diagnostics(name: &str) -> (Rc<Entry>, Vec<Diagnostic>) {
+    let mut store = YangStore::new();
+    store.add_path(YANG_DIR);
+    store.read_with_resolve(name).expect("parse / resolve");
+    store.identity_resolve();
+    let module = store.find_module(name).expect("module found");
+    let entry = to_entry(&store, module);
+    (entry, store.take_diagnostics())
+}
+
+fn find_child(ent: &Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
+    ent.dir.borrow().iter().find(|e| e.name == name).cloned()
+}
+
+#[test]
+fn well_formed_schema_reports_nothing() {
+    // The baseline that makes the rest meaningful: a healthy module must
+    // not produce noise, or "no diagnostics" would be worthless as a
+    // signal.
+    let (_, diags) = load_with_diagnostics("augment-target");
+    assert!(diags.is_empty(), "expected no diagnostics, got {diags:?}");
+}
+
+#[test]
+fn top_level_augment_target_must_be_absolute() {
+    let (root, diags) = load_with_diagnostics("augment-relative-target");
+    assert_eq!(
+        diags,
+        vec![Diagnostic::AugmentTargetNotAbsolute {
+            module: "augment-relative-target".into(),
+            target: "art:box".into(),
+        }]
+    );
+
+    // The node still resolved by name, so the augment applied: the
+    // diagnostic reports a malformed target, it does not discard work.
+    let box_ = find_child(&root, "box").expect("box container");
+    assert!(find_child(&box_, "added").is_some());
+}
+
+#[test]
+fn uses_augment_target_must_be_descendant() {
+    let (_, diags) = load_with_diagnostics("uses-augment-absolute-target");
+    assert_eq!(
+        diags,
+        vec![Diagnostic::AugmentTargetNotDescendant {
+            module: "uses-augment-absolute-target".into(),
+            target: "/box".into(),
+        }]
+    );
+}
+
+#[test]
+fn unresolvable_target_names_the_missing_segment() {
+    let (_, diags) = load_with_diagnostics("augment-missing-target");
+    match diags.as_slice() {
+        [
+            Diagnostic::AugmentTargetNotFound {
+                kind,
+                module,
+                target,
+                missing,
+            },
+        ] => {
+            assert_eq!(*kind, AugmentKind::Augment);
+            assert_eq!(module, "augment-missing-target");
+            assert_eq!(target, "/amt:box/amt:absent");
+            // The failing segment is the actionable part — it says how
+            // far the path got before it broke.
+            assert!(
+                missing.contains("absent"),
+                "missing segment should name the node that did not match: {missing}"
+            );
+        }
+        other => panic!("expected one AugmentTargetNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn augment_into_leaf_is_reported() {
+    let (_, diags) = load_with_diagnostics("augment-leaf-target");
+    match diags.as_slice() {
+        [Diagnostic::AugmentIntoLeaf { module, leaf, .. }] => {
+            assert_eq!(module, "augment-leaf-target");
+            assert_eq!(leaf, "target");
+        }
+        other => panic!("expected one AugmentIntoLeaf, got {other:?}"),
+    }
+}
+
+#[test]
+fn duplicate_node_is_reported() {
+    let (_, diags) = load_with_diagnostics("augment-dup");
+    match diags.as_slice() {
+        [Diagnostic::AugmentDuplicateNode { module, name, .. }] => {
+            assert_eq!(module, "augment-dup");
+            assert_eq!(name, "base");
+        }
+        other => panic!("expected one AugmentDuplicateNode, got {other:?}"),
+    }
+}
+
+#[test]
+fn diagnostics_render_with_module_and_target() {
+    // Callers that only print the diagnostic still need to know which
+    // module and node are at fault.
+    let (_, diags) = load_with_diagnostics("augment-missing-target");
+    let text = diags[0].to_string();
+    assert!(text.contains("augment-missing-target"), "{text}");
+    assert!(text.contains("/amt:box/amt:absent"), "{text}");
+}
+
+#[test]
+fn take_diagnostics_drains_and_accessor_borrows() {
+    let mut store = YangStore::new();
+    store.add_path(YANG_DIR);
+    store
+        .read_with_resolve("augment-dup")
+        .expect("parse / resolve");
+    store.identity_resolve();
+    let module = store.find_module("augment-dup").expect("module found");
+    let _ = to_entry(&store, module);
+
+    // Borrowing accessor sees the diagnostic ...
+    assert_eq!(store.diagnostics().len(), 1);
+    // ... and still does, because reading does not consume.
+    assert_eq!(store.diagnostics().len(), 1);
+
+    // Taking drains, so a caller checking one module at a time does not
+    // re-report earlier findings.
+    assert_eq!(store.take_diagnostics().len(), 1);
+    assert!(store.diagnostics().is_empty());
+}

--- a/tests/yang/augment-missing-target.yang
+++ b/tests/yang/augment-missing-target.yang
@@ -1,0 +1,18 @@
+module augment-missing-target {
+  yang-version "1.1";
+  namespace "urn:test:augment-missing-target";
+  prefix "amt";
+
+  container box {
+    leaf base {
+      type string;
+    }
+  }
+
+  // Targets a node that does not exist; the augment cannot be applied.
+  augment "/amt:box/amt:absent" {
+    leaf added {
+      type string;
+    }
+  }
+}

--- a/tests/yang/augment-relative-target.yang
+++ b/tests/yang/augment-relative-target.yang
@@ -1,0 +1,20 @@
+module augment-relative-target {
+  yang-version "1.1";
+  namespace "urn:test:augment-relative-target";
+  prefix "art";
+
+  container box {
+    leaf base {
+      type string;
+    }
+  }
+
+  // RFC 7950 §7.17: a top-level augment's target must be an absolute
+  // schema-node-identifier. This one omits the leading '/', which is a
+  // diagnostic even though the node still resolves by name.
+  augment "art:box" {
+    leaf added {
+      type string;
+    }
+  }
+}

--- a/tests/yang/uses-augment-absolute-target.yang
+++ b/tests/yang/uses-augment-absolute-target.yang
@@ -1,0 +1,25 @@
+module uses-augment-absolute-target {
+  yang-version "1.1";
+  namespace "urn:test:uses-augment-absolute-target";
+  prefix "uaat";
+
+  grouping g {
+    container box {
+      leaf base {
+        type string;
+      }
+    }
+  }
+
+  container top {
+    // RFC 7950 §7.17: a uses-substatement augment's target must be a
+    // descendant schema-node-identifier. The leading '/' here is wrong.
+    uses g {
+      augment "/box" {
+        leaf added {
+          type string;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #31, which noted these five `eprintln!` sites as the one
piece of "the library shouldn't print" left unfixed.

## Problem

`to_entry` wrote five classes of malformed-augment warning straight to
stderr and carried on. That leaves a library deciding how an application
reports its problems, and gives callers no way to react: a schema with a
dangling augment target looks identical to a healthy one unless a human
happens to be watching the terminal at startup.

## Fix

Collect them on the store. `YangStore` grows a
`RefCell<Vec<Diagnostic>>` plus `diagnostics()` / `take_diagnostics()`.
`to_entry` already takes the store by shared reference and the whole
augment path has it in scope, so the interior mutability means **no
function needs a new parameter** — the alternative was threading a
collector through the ~20 functions that take `store: &YangStore`.

The new `Diagnostic` enum keeps each finding structured — the module at
fault, the target, and the offending node or path segment — so callers
can match on the kind instead of parsing a message:

```rust
pub enum Diagnostic {
    AugmentTargetNotAbsolute { module, target },
    AugmentTargetNotDescendant { module, target },
    AugmentTargetNotFound { kind, module, target, missing },
    AugmentIntoLeaf { module, target, leaf },
    AugmentDuplicateNode { module, target, name },
}
```

`Display` renders the previous text plus the module name, which the
stderr output never included. `AugmentKind` distinguishes a top-level
`augment` from a `uses` substatement, replacing a `&str` label that was
threaded into `resolve_and_inject`.

These remain **warnings**: the tree is still produced, with the
offending augment skipped or its duplicate child dropped. Existing
behaviour is unchanged, and `tests/augment.rs` still covers it.

## Tests

`tests/augment_diagnostics.rs` — one test per variant (three new
fixtures; the leaf-target and duplicate cases reuse the fixtures that
already existed), the accessor drain/borrow semantics, and a baseline
that a well-formed module reports **nothing**. That baseline is the one
that makes the rest meaningful: without it, "no diagnostics" would be a
worthless signal.

## Verification

- 13 suites green, `cargo fmt --check` clean, `clippy --all-targets --
  -D warnings` clean.
- zebra-rs compiles unchanged against this branch and its full 1662-test
  suite passes; the API is additive, so it needs no source change.
- Ran against a real schema: zebra-rs's 89 YANG files produce **zero**
  diagnostics in both its `configure` and `exec` trees, so this is not
  quietly reclassifying existing noise.

Non-breaking on its own, though it lands before 2.0.0 is published
(crates.io still has 1.1.0).

Generated with [Claude Code](https://claude.com/claude-code)