### PR TITLE
Correct the README for 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ to drive configuration and validation.
 - Module loading with automatic `import` / `include` (submodule) resolution.
 - `typedef`, `grouping`, `identity`, and `union` resolution.
 - An `Entry` tree suitable for building config schemas and validators.
+- Deterministic output: the tree has the same shape on every run, so it can be
+  diffed or used to generate golden files.
+- Errors and schema problems are returned, never printed.
 
 ## Installation
 
@@ -21,7 +24,7 @@ Add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-libyang = "1"
+libyang = "2"
 ```
 
 ## Usage
@@ -59,13 +62,56 @@ parse(&input, "ietf-bgp", &mut grammar).expect("parse");
 let node = yang(grammar).expect("build node tree");
 ```
 
+## Diagnostics
+
+A malformed `augment` — a target that does not resolve, one that lands on a
+leaf, or one that introduces a name the target already has — does not stop the
+build: the tree is still produced with that augment skipped. Those findings are
+collected on the store rather than written to stderr, so the caller decides
+whether to log them, fail, or ignore them:
+
+```rust
+use libyang::{to_entry, YangStore};
+
+let mut store = YangStore::new();
+store.add_path("yang");
+store.read_with_resolve("ietf-bgp").expect("parse and resolve");
+store.identity_resolve();
+
+let module = store.find_module("ietf-bgp").expect("module found");
+let entry = to_entry(&store, module);
+
+for diagnostic in store.take_diagnostics() {
+    eprintln!("warning: {diagnostic}");
+}
+```
+
+Each `Diagnostic` names the module at fault along with the target and the
+offending node, and can be matched on rather than parsed.
+
+## Migrating from 1.x
+
+2.0 is a breaking release:
+
+- `YangStore::read` is gone. Use `read_with_resolve`, which loads each module
+  once (so mutually importing modules terminate) and keeps submodules.
+- `YangStore::modules` and `submodules` are private. Use `find_module` /
+  `find_submodule`.
+- `YangError`'s variants carry the file, module and underlying parse
+  diagnostic, and the enum is `#[non_exhaustive]`. Parse failures are returned
+  instead of being printed to stdout.
+- Augment problems are collected as `Diagnostic`s (see above) instead of being
+  written to stderr.
+- `RangeNode` implements `Display` instead of having an inherent `to_string`;
+  `.to_string()` still works.
+
 ## How it works
 
 The pipeline runs in four stages:
 
 1. **Parse** — YANG text is parsed by the `parol`-generated grammar into a `YangGrammar` AST.
 2. **AST** — `yang()` converts the grammar tree into structured `Node` values.
-3. **Resolve** — `YangStore` loads imports/includes, merges submodules, and resolves typedefs, groupings, and identities.
+3. **Resolve** — `YangStore` loads imports and includes, keeping submodules addressable through `find_submodule`, and resolves typedefs, groupings, and identities. Modules that import each other are loaded once, so cycles terminate.
 4. **Entry** — `to_entry()` produces an `Entry` tree for data modeling and validation.
 
 ## Testing


### PR DESCRIPTION
## Corrections

- The install snippet still pinned `libyang = "1"`.
- The pipeline description still described the removed `YangStore::read`.
  It said resolution "merges submodules", which was that function's
  behaviour — it merged a submodule's groupings into the parent and
  discarded the rest. `read_with_resolve` keeps submodules addressable
  through `find_submodule`, and loads each module once so mutually
  importing modules terminate.

## Additions

2.0 changed behaviour that a user would notice, so the README now covers
it rather than leaving it to the API docs:

- A **Diagnostics** section: malformed augments no longer print to
  stderr, they are collected on the store. Anyone upgrading who was
  relying on that output needs to know where it went.
- A **Migrating from 1.x** list of the breaking changes.
- Two feature bullets for the properties that are now guaranteed:
  deterministic tree shape, and errors returned rather than printed.

## Verification

All three code examples in the README were compile-checked against 2.0
(built as a temporary example, not committed). Nothing else in the file
was inaccurate.

Note: 2.0.0 is already published, so these corrections will reach
crates.io and docs.rs only with the next release. They are live on
GitHub immediately.

Generated with [Claude Code](https://claude.com/claude-code)